### PR TITLE
Usage of `None` for whenNext

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Paper: Philipp Haller, Simon Geries, Michael Eichberg, and Guido Salvaneschi.
        [Reactive Async: Expressive Deterministic Concurrency](http://www.csc.kth.se/~phaller/doc/haller16-scala.pdf).
        Proc. ACM SIGPLAN Scala Symposium. ACM, 2016. [[ACM DL](http://dl.acm.org/citation.cfm?id=2998396)]
 
+Master's thesis: Simon Geries. [Reactive Async: Safety and efficiency
+of new abstractions for reactive, asynchronous
+programming](http://urn.kb.se/resolve?urn=urn%3Anbn%3Ase%3Akth%3Adiva-191330). KTH,
+School of Computer Science and Communication (CSC). 2016.
+
 ## Building
 
 Building Reactive Async requires

--- a/core/src/main/scala/cell/Cell.scala
+++ b/core/src/main/scala/cell/Cell.scala
@@ -43,7 +43,7 @@ trait Cell[K <: Key[V], V] {
    *               `pred` is applied to value of `other` cell.
    * @param value  Early result value.
    */
-  def whenComplete(other: Cell[K, V], pred: V => Boolean, value: Option[V]): Unit
+  def whenComplete(other: Cell[K, V], pred: V => Boolean, value: V): Unit
   def whenComplete(other: Cell[K, V], pred: V => Boolean, valueCallback: V => Option[V]): Unit
 
   /**
@@ -60,7 +60,7 @@ trait Cell[K <: Key[V], V] {
    *               `pred` is applied to value of `other` cell.
    * @param value  Early result value.
    */
-  def whenNext(other: Cell[K, V], pred: V => WhenNextPredicate, value: Option[V]): Unit
+  def whenNext(other: Cell[K, V], pred: V => WhenNextPredicate, value: V): Unit
   def whenNext(other: Cell[K, V], pred: V => WhenNextPredicate, valueCallback: V => Option[V]): Unit
 
   def zipFinal(that: Cell[K, V]): Cell[DefaultKey[(V, V)], (V, V)]
@@ -345,14 +345,13 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
    *  or `WhenNextComplete`, `this` cell receives an intermediate or a final result `value`
    *  respectively.
    *
-   *  If `value` is `Some(v)`, then the shortcut value is `v`. Otherwise if `value` is `None`,
-    *  the cell is not updated.
+   *  `value` is the shortcut value is `v`.
    *
    *  The thereby introduced dependency is removed when `this` cell
    *  is completed (either prior or after an invocation of `whenNext`).
    */
-  override def whenNext(other: Cell[K, V], pred: V => WhenNextPredicate, value: Option[V]): Unit = {
-    whenNext(other, pred, (v:V) => value)
+  override def whenNext(other: Cell[K, V], pred: V => WhenNextPredicate, value: V): Unit = {
+    whenNext(other, pred, (v:V) => Some(value))
   }
   
    /** Adds dependency on `other` cell: when `other` cell receives an intermediate result by using
@@ -399,8 +398,8 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
    *  The thereby introduced dependency is removed when `this` cell
    *  is completed (either prior or after an invocation of `whenComplete`).
    */   
-  override def whenComplete(other: Cell[K, V], pred: V => Boolean, value: Option[V]): Unit = { 
-    whenComplete(other, pred, (v:V) => value)
+  override def whenComplete(other: Cell[K, V], pred: V => Boolean, value: V): Unit = {
+    whenComplete(other, pred, (v:V) => Some(value))
   }
   
 

--- a/core/src/main/scala/cell/Cell.scala
+++ b/core/src/main/scala/cell/Cell.scala
@@ -32,41 +32,41 @@ trait Cell[K <: Key[V], V] {
   def isComplete: Boolean
 
   /**
-   * Adds a dependency on some `other` cell.
-   *
-   * Example:
-   *   whenComplete(cell, x => !x, Impure) // if `cell` is completed and the predicate is true (meaning
-   *                                       // `cell` is impure), `this` cell can be completed with constant `Impure`
-   *
-   * @param other  Cell that `this` Cell depends on.
-   * @param pred   Predicate used to decide whether a final result of `this` Cell can be computed early.
-   *               `pred` is applied to value of `other` cell.
-   * @param value  Early result value.
-   */
+    * Adds a dependency on some `other` cell.
+    *
+    * Example:
+    *   whenComplete(cell, x => !x, Impure) // if `cell` is completed and the predicate is true (meaning
+    *                                       // `cell` is impure), `this` cell can be completed with constant `Impure`
+    *
+    * @param other  Cell that `this` Cell depends on.
+    * @param pred   Predicate used to decide whether a final result of `this` Cell can be computed early.
+    *               `pred` is applied to value of `other` cell.
+    * @param value  Early result value.
+    */
   def whenComplete(other: Cell[K, V], pred: V => Boolean, value: Option[V]): Unit
 
   /**
-   * Adds a dependency on some `other` cell.
-   *
-   * Example:
-   *   whenNext(cell, x => !x, Impure) // if a preliminary result is put in `cell` using 
-   *                                   // `putNext`and the predicate is true (meaning `cell`
-   *                                   // is impure), `this`cell can receive next intermediate
-   *                                   // result with constant `Impure`
-   *
-   * @param other  Cell that `this` Cell depends on.
-   * @param pred   Predicate used to decide whether an intermediate or final result of `this` Cell can be computed early, depending on what the predicate returns.
-   *               `pred` is applied to value of `other` cell.
-   * @param value  Early result value.
-   */
+    * Adds a dependency on some `other` cell.
+    *
+    * Example:
+    *   whenNext(cell, x => !x, Impure) // if a preliminary result is put in `cell` using
+    *                                   // `putNext`and the predicate is true (meaning `cell`
+    *                                   // is impure), `this`cell can receive next intermediate
+    *                                   // result with constant `Impure`
+    *
+    * @param other  Cell that `this` Cell depends on.
+    * @param pred   Predicate used to decide whether an intermediate or final result of `this` Cell can be computed early, depending on what the predicate returns.
+    *               `pred` is applied to value of `other` cell.
+    * @param value  Early result value.
+    */
   def whenNext(other: Cell[K, V], pred: V => WhenNextPredicate, value: Option[V]): Unit
 
   def zipFinal(that: Cell[K, V]): Cell[DefaultKey[(V, V)], (V, V)]
 
   /**
-   * Registers a call-back function to be invoked when quiescence is reached, but `this` cell has not been
-   * completed, yet. The call-back function is passed a sequence of the cells that `this` cell depends on.
-   */
+    * Registers a call-back function to be invoked when quiescence is reached, but `this` cell has not been
+    * completed, yet. The call-back function is passed a sequence of the cells that `this` cell depends on.
+    */
   // def onCycle(callback: Seq[Cell[K, V]] => V)
 
   // internal API
@@ -139,13 +139,13 @@ object Cell {
 
 
 /**
- * Interface trait for programmatically completing a cell. Analogous to `Promise[V]`.
- */
+  * Interface trait for programmatically completing a cell. Analogous to `Promise[V]`.
+  */
 trait CellCompleter[K <: Key[V], V] {
 
   /**
-   * The cell associated with this completer.
-   */
+    * The cell associated with this completer.
+    */
   def cell: Cell[K, V]
 
   def putFinal(x: V): Unit
@@ -161,9 +161,9 @@ trait CellCompleter[K <: Key[V], V] {
 object CellCompleter {
 
   /**
-   * Create a completer for a cell holding values of type `V`
-   * given a `HandlerPool` and a `Key[V]`.
-   */
+    * Create a completer for a cell holding values of type `V`
+    * given a `HandlerPool` and a `Key[V]`.
+    */
   def apply[K <: Key[V], V](pool: HandlerPool, key: K)(implicit lattice: Lattice[V]): CellCompleter[K, V] = {
     val impl = new CellImpl[K, V](pool, key, lattice)
     pool.register(impl)
@@ -197,12 +197,12 @@ class Dep[K <: Key[V], V](val cell: Cell[K, V], val pred: V => Boolean, val valu
  * @param callbacks list of registered call-back runnables
  */
 private class State[K <: Key[V], V](
-  val res: V,
-  val deps: Map[Cell[K, V], List[CompleteDepRunnable[K, V]]],
-  val callbacks: Map[Cell[K, V], List[CompleteCallbackRunnable[K, V]]],
-  val nextDeps: Map[Cell[K, V], List[NextDepRunnable[K, V]]],
-  val nextCallbacks: Map[Cell[K, V], List[NextCallbackRunnable[K, V]]]
-)
+                                     val res: V,
+                                     val deps: Map[Cell[K, V], List[CompleteDepRunnable[K, V]]],
+                                     val callbacks: Map[Cell[K, V], List[CompleteCallbackRunnable[K, V]]],
+                                     val nextDeps: Map[Cell[K, V], List[NextDepRunnable[K, V]]],
+                                     val nextCallbacks: Map[Cell[K, V], List[NextCallbackRunnable[K, V]]]
+                                   )
 
 private object State {
   def empty[K <: Key[V], V](lattice: Lattice[V]): State[K, V] =
@@ -339,24 +339,24 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
   }
 
   /** Adds dependency on `other` cell: when `other` cell receives an intermediate result by using
-   *  `putNext`, evaluate `pred` with the result of `other`. If this evaluation yields `WhenNext`
-   *  or `WhenNextComplete`, `this` cell receives an intermediate or a final result `value`
-   *  respectively.
-   *
-   *  If `value` is `Some(v)`, then the shortcut value is `v`. Otherwise if `value` is `None`,
-   *  then the shortcut value is the same value as the value `other` receives when the
-   *  whenNext dependency is triggered.
-   *
-   *  The thereby introduced dependency is removed when `this` cell
-   *  is completed (either prior or after an invocation of `whenNext`).
-   */
+    *  `putNext`, evaluate `pred` with the result of `other`. If this evaluation yields `WhenNext`
+    *  or `WhenNextComplete`, `this` cell receives an intermediate or a final result `value`
+    *  respectively.
+    *
+    *  If `value` is `Some(v)`, then the shortcut value is `v`. Otherwise if `value` is `None`,
+    *  then the shortcut value is the same value as the value `other` receives when the
+    *  whenNext dependency is triggered.
+    *
+    *  The thereby introduced dependency is removed when `this` cell
+    *  is completed (either prior or after an invocation of `whenNext`).
+    */
   override def whenNext(other: Cell[K, V], pred: V => WhenNextPredicate, value: Option[V]): Unit = {
     var success = false
     while (!success) {
       state.get() match {
         case finalRes: Try[_] => // completed with final result
-        // do not add dependency
-        // in fact, do nothing
+          // do not add dependency
+          // in fact, do nothing
           success = true
 
         case raw: State[_, _] => // not completed
@@ -377,17 +377,17 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
   }
 
   /** Adds dependency on `other` cell: when `other` cell is completed, evaluate `pred`
-   *  with the result of `other`. If this evaluation yields true, complete `this` cell
-   *  with `value`.
-   *
-   *  The thereby introduced dependency is removed when `this` cell
-   *  is completed (either prior or after an invocation of `whenComplete`).
-   */
+    *  with the result of `other`. If this evaluation yields true, complete `this` cell
+    *  with `value`.
+    *
+    *  The thereby introduced dependency is removed when `this` cell
+    *  is completed (either prior or after an invocation of `whenComplete`).
+    */
   override def whenComplete(other: Cell[K, V], pred: V => Boolean, value: Option[V]): Unit = {
     state.get() match {
       case finalRes: Try[_]  => // completed with final result
-        // do not add dependency
-        // in fact, do nothing
+      // do not add dependency
+      // in fact, do nothing
 
       case raw: State[_, _] => // not completed
         val newDep = new CompleteDepRunnable(pool, other, pred, value, this)
@@ -459,8 +459,8 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
   }
 
   /** Called by `tryComplete` to store the resolved value and get the current state
-   *  or `null` if it is already completed.
-   */
+    *  or `null` if it is already completed.
+    */
   // TODO: take care of compressing root (as in impl.Promise.DefaultPromise)
   @tailrec
   private def tryCompleteAndGetState(v: Try[V]): AnyRef = {
@@ -605,9 +605,9 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
   }
 
   /** Tries to add the callback, if already completed, it dispatches the callback to be executed.
-   *  Used by `onComplete()` to add callbacks to a promise and by `link()` to transfer callbacks
-   *  to the root promise when linking two promises together.
-   */
+    *  Used by `onComplete()` to add callbacks to a promise and by `link()` to transfer callbacks
+    *  to the root promise when linking two promises together.
+    */
   @tailrec
   private def dispatchOrAddCallback(runnable: CompleteCallbackRunnable[K, V]): Unit = {
     state.get() match {
@@ -632,8 +632,8 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
   private def dispatchOrAddNextCallback(runnable: NextCallbackRunnable[K, V]): Unit = {
     state.get() match {
       case r: Try[V]  => runnable.executeWithValue(r.asInstanceOf[Try[V]])
-                          /* Cell is completed, do nothing emit an onNext callback */
-                         // case _: DefaultPromise[_] => compressedRoot().dispatchOrAddCallback(runnable)
+      /* Cell is completed, do nothing emit an onNext callback */
+      // case _: DefaultPromise[_] => compressedRoot().dispatchOrAddCallback(runnable)
       case pre: State[_, _] =>
         // assemble new state
         val current  = pre.asInstanceOf[State[K, V]]
@@ -667,7 +667,7 @@ private class CompleteDepRunnable[K <: Key[V], V](val pool: HandlerPool,
                                                   val pred: V => Boolean,
                                                   val shortCutValue: Option[V],
                                                   val completer: CellCompleter[K, V])
-    extends Runnable with OnCompleteRunnable with (Try[V] => Unit) {
+  extends Runnable with OnCompleteRunnable with (Try[V] => Unit) {
   // must be filled in before running it
   var value: Try[V] = null
 
@@ -676,7 +676,7 @@ private class CompleteDepRunnable[K <: Key[V], V](val pool: HandlerPool,
       if (pred(v)) {
         shortCutValue match {
           case Some(scv) => completer.putFinal(scv)
-          case None => completer.putFinal(v)
+          case None => /* do nothing */
         }
       }
       else {
@@ -729,7 +729,7 @@ private class NextDepRunnable[K <: Key[V], V](val pool: HandlerPool,
                                               val pred: V => WhenNextPredicate,
                                               val shortCutValue: Option[V],
                                               val completer: CellCompleter[K, V])
-    extends Runnable with OnCompleteRunnable with (Try[V] => Unit) {
+  extends Runnable with OnCompleteRunnable with (Try[V] => Unit) {
   var value: Try[V] = null
 
   override def apply(x: Try[V]): Unit = {
@@ -739,12 +739,12 @@ private class NextDepRunnable[K <: Key[V], V](val pool: HandlerPool,
           case WhenNext =>
             shortCutValue match {
               case Some(scv) => completer.putNext(scv)
-              case None => completer.putNext(v)
+              case None => /* do nothing */
             }
           case WhenNextComplete =>
             shortCutValue match {
               case Some(scv) => completer.putFinal(scv)
-              case None => completer.putFinal(v)
+              case None => /* do nothing */
             }
           case _ => /* do nothing */
         }
@@ -764,10 +764,10 @@ private class NextDepRunnable[K <: Key[V], V](val pool: HandlerPool,
 }
 
 /**
- * @param executor The thread that runs the callback function
- * @param onNext   Callback function that is triggered on an onNext event
- * @param dependee The cell that depends on this callback
- */
+  * @param executor The thread that runs the callback function
+  * @param onNext   Callback function that is triggered on an onNext event
+  * @param dependee The cell that depends on this callback
+  */
 private class NextCallbackRunnable[K <: Key[V], V](val executor: HandlerPool, val onNext: Try[V] => Any, val dependee: Cell[K, V]) {
   def executeWithValue(v: Try[V]): Unit = {
     // Note that we cannot prepare the ExecutionContext at this point, since we might
@@ -775,4 +775,3 @@ private class NextCallbackRunnable[K <: Key[V], V](val executor: HandlerPool, va
     try executor.execute(() => onNext(v)) catch { case NonFatal(t) => executor reportFailure t }
   }
 }
-

--- a/core/src/main/scala/opal/ImmutabilityAnalysis.scala
+++ b/core/src/main/scala/opal/ImmutabilityAnalysis.scala
@@ -269,7 +269,7 @@ object ImmutabilityAnalysis extends DefaultOneStepAnalysis {
                       case Mutable | ConditionallyImmutable => WhenNext
                       case Immutable => FalsePred
                     },
-                    Some(ConditionallyImmutable)
+                    ConditionallyImmutable
                   )
                 case None => /* Do nothing */
               }
@@ -290,7 +290,7 @@ object ImmutabilityAnalysis extends DefaultOneStepAnalysis {
             case Mutable => WhenNextComplete
             case ConditionallyImmutable => WhenNext
           },
-          None
+          Some(_)
         )
       }
     }
@@ -322,7 +322,7 @@ object ImmutabilityAnalysis extends DefaultOneStepAnalysis {
             case Mutable => WhenNextComplete
             case ConditionallyImmutable => WhenNext
           },
-          None
+          Some(_)
         )
       } else {
         val unavailableSubtype = directSubtypes.find(t ⇒ project.classFile(t).isEmpty)
@@ -340,7 +340,7 @@ object ImmutabilityAnalysis extends DefaultOneStepAnalysis {
                 case Mutable => WhenNextComplete
                 case ConditionallyImmutable => WhenNext
               },
-              None
+              Some(_)
             )
           }
         }

--- a/core/src/main/scala/opal/PurityAnalysis.scala
+++ b/core/src/main/scala/opal/PurityAnalysis.scala
@@ -179,7 +179,7 @@ object PurityAnalysis extends DefaultOneStepAnalysis {
 
                 val targetCellCompleter = methodToCellCompleter(callee)
                 hasDependencies = true
-                cellCompleter.cell.whenComplete(targetCellCompleter.cell, (p: Purity) => p == Impure, Some(Impure))
+                cellCompleter.cell.whenComplete(targetCellCompleter.cell, (p: Purity) => p == Impure, Impure)
             }
         }
 

--- a/core/src/test/scala/cell/base.scala
+++ b/core/src/test/scala/cell/base.scala
@@ -105,7 +105,7 @@ class BaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "someotherkey")
 
     val cell1 = completer1.cell
-    cell1.whenComplete(completer2.cell, (x: Int) => x == 10, Some(20))
+    cell1.whenComplete(completer2.cell, (x: Int) => x == 10, 20)
 
     cell1.onComplete {
       case Success(v) =>
@@ -131,7 +131,7 @@ class BaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "someotherkey")
 
     val cell1 = completer1.cell
-    cell1.whenComplete(completer2.cell, (x: Int) => x == 10, Some(20))
+    cell1.whenComplete(completer2.cell, (x: Int) => x == 10, 20)
 
     cell1.onComplete {
       case Success(v) =>
@@ -157,7 +157,7 @@ class BaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "someotherkey")
 
     val cell1 = completer1.cell
-    cell1.whenComplete(completer2.cell, (x: Int) => x == 10, Some(20))
+    cell1.whenComplete(completer2.cell, (x: Int) => x == 10, 20)
 
     completer2.putFinal(9)
 
@@ -174,7 +174,7 @@ class BaseSuite extends FunSuite {
     val completer1 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
     val completer2 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
 
-    completer1.cell.whenComplete(completer2.cell, (imm: Immutability) => imm == Mutable, Some(Mutable))
+    completer1.cell.whenComplete(completer2.cell, (imm: Immutability) => imm == Mutable, Mutable)
 
     completer1.putFinal(Immutable)
     assert(completer2.cell.numCompleteCallbacks == 0)
@@ -221,7 +221,7 @@ class BaseSuite extends FunSuite {
     cell1.whenNext(completer2.cell, (x: Int) => {
                      if(x == 10) WhenNext
                      else FalsePred
-                   }, Some(20))
+                   }, 20)
 
     cell1.onNext {
       case Success(x) =>
@@ -251,7 +251,7 @@ class BaseSuite extends FunSuite {
     cell1.whenNext(completer2.cell, (x: Int) => {
                      if(x == 10) WhenNext
                      else FalsePred
-                   }, Some(20))
+                   }, 20)
 
     cell1.onNext {
       case Success(x) =>
@@ -281,8 +281,8 @@ class BaseSuite extends FunSuite {
     cell1.whenNext(completer2.cell, (x: Int) => {
                      if(x == 10) WhenNext
                      else FalsePred
-                   }, Some(30))
-    cell1.whenComplete(completer2.cell, (x: Int) => x == 10, Some(20))
+                   }, 30)
+    cell1.whenComplete(completer2.cell, (x: Int) => x == 10, 20)
 
     assert(cell1.numNextDependencies == 1)
 
@@ -320,7 +320,7 @@ class BaseSuite extends FunSuite {
     cell1.whenNext(completer2.cell, (x: Int) => {
                      if(x == 10) WhenNext
                      else FalsePred
-                   }, Some(20))
+                   }, 20)
 
     assert(cell1.numNextDependencies == 1)
 
@@ -349,7 +349,7 @@ class BaseSuite extends FunSuite {
     cell1.whenNext(completer2.cell, (x: Int) => {
                      if(x == 10) WhenNext
                      else FalsePred
-                   }, Some(20))
+                   }, 20)
 
     completer2.putFinal(10)
 
@@ -371,7 +371,7 @@ class BaseSuite extends FunSuite {
     completer1.cell.whenNext(completer2.cell, (imm: Immutability) => imm match {
       case Mutable => WhenNext
       case _ => FalsePred
-    }, Some(Mutable))
+    }, Mutable)
 
     completer1.putFinal(Immutable)
     assert(completer2.cell.numNextCallbacks == 0)
@@ -393,7 +393,7 @@ class BaseSuite extends FunSuite {
       pool.execute( () => {
         completer1.cell.whenNext(completer2.cell, (x: Immutability) => {
           if (x == Mutable) WhenNext else FalsePred
-        }, Some(Mutable))
+        }, Mutable)
         latch.countDown()
       })
     }
@@ -414,7 +414,7 @@ class BaseSuite extends FunSuite {
       completer1.cell.whenNext(completer2.cell, (imm: Immutability) => imm match {
         case Immutable | ConditionallyImmutable => FalsePred
         case Mutable => WhenNext
-      }, Some(Mutable))
+      }, Mutable)
 
       assert(completer1.cell.numTotalDependencies == 1)
 
@@ -442,7 +442,7 @@ class BaseSuite extends FunSuite {
     cell1.whenNext(completer2.cell, (x: Int) => {
                      if(x == 10) WhenNextComplete
                      else FalsePred
-                   }, Some(20))
+                   }, 20)
 
     cell1.onComplete {
       case Success(v) =>
@@ -481,7 +481,7 @@ class BaseSuite extends FunSuite {
     cell1.whenNext(completer2.cell, (x: Int) => {
                      if(x == 10) WhenNextComplete
                      else FalsePred
-                   }, Some(20))
+                   }, 20)
 
     cell1.onComplete {
       case Success(x) =>
@@ -512,7 +512,7 @@ class BaseSuite extends FunSuite {
     cell1.whenNext(completer2.cell, (x: Int) => {
                      if(x == 10) WhenNextComplete
                      else FalsePred
-                   }, Some(20))
+                   }, 20)
 
     cell1.onNext {
       case Success(x) =>
@@ -561,8 +561,8 @@ class BaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "key2")
     val cell1 = completer1.cell
     val cell2 = completer2.cell
-    cell1.whenComplete(cell2, (x: Int) => x == 1, Some(1))
-    cell2.whenComplete(cell1, (x: Int) => x == 1, Some(1))
+    cell1.whenComplete(cell2, (x: Int) => x == 1, 1)
+    cell2.whenComplete(cell1, (x: Int) => x == 1, 1)
     val incompleteFut = pool.quiescentIncompleteCells
     val cells = Await.result(incompleteFut, 2.seconds)
     assert(cells.map(_.key).toString == "List(key1, key2)")
@@ -574,8 +574,8 @@ class BaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "key2")
     val cell1 = completer1.cell
     val cell2 = completer2.cell
-    cell1.whenComplete(cell2, (x: Int) => x == 0, Some(0))
-    cell2.whenComplete(cell1, (x: Int) => x == 0, Some(0))
+    cell1.whenComplete(cell2, (x: Int) => x == 0, 0)
+    cell2.whenComplete(cell1, (x: Int) => x == 0, 0)
     val qfut = pool.quiescentResolveCell
     Await.ready(qfut, 2.seconds)
     val incompleteFut = pool.quiescentIncompleteCells

--- a/core/src/test/scala/internalBase.scala
+++ b/core/src/test/scala/internalBase.scala
@@ -25,8 +25,8 @@ class InternalBaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "key2")
     val cell1 = completer1.cell
     val cell2 = completer2.cell
-    cell1.whenComplete(cell2, (x: Int) => x == 0, Some(0))
-    cell1.whenComplete(cell2, (x: Int) => x == 0, Some(0))
+    cell1.whenComplete(cell2, (x: Int) => x == 0, 0)
+    cell1.whenComplete(cell2, (x: Int) => x == 0, 0)
 
     assert(cell1.numCompleteDependencies == 2)
     assert(cell2.numCompleteDependencies == 0)
@@ -38,8 +38,8 @@ class InternalBaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "key2")
     val cell1 = completer1.cell
     val cell2 = completer2.cell
-    cell1.whenComplete(cell2, (x: Int) => x == 0, Some(0))
-    cell1.whenComplete(cell2, (x: Int) => x == 0, Some(0))
+    cell1.whenComplete(cell2, (x: Int) => x == 0, 0)
+    cell1.whenComplete(cell2, (x: Int) => x == 0, 0)
 
     completer1.putFinal(0)
 


### PR DESCRIPTION
The valueCallback for whenNext/whenComplete can fail. With this PR `None` is used to signal, that no change should be performed.
This meaning of `None` contradicts the meaning of `None` if passed to whenNext directly (i.e. propagate from the target cell). So this is forbidden now by changing the signature of whenNext to not accept Option[V] but V directly.
The old behaviour for `None` can be emulated by passing the callback `Some(_)` as third parameter.