### PR TITLE
Exception-throwing tasks do not run quiescent handlers

### DIFF
--- a/core/src/test/scala/cell/base.scala
+++ b/core/src/test/scala/cell/base.scala
@@ -929,6 +929,7 @@ class BaseSuite extends FunSuite {
     val completer = CellCompleter[key.type, Int](pool, key)(intMaxLattice)
 
     pool.execute{() =>
+      // NOTE: This will print a stacktrace, but that is fine (not a bug).
       throw new Exception(
         "Even if this happens, quiescent handlers should still run.")
     }

--- a/core/src/test/scala/cell/base.scala
+++ b/core/src/test/scala/cell/base.scala
@@ -918,6 +918,30 @@ class BaseSuite extends FunSuite {
     assert(mutability6 == Mutable)
   }
 
+  test("if exception-throwing tasks should still run quiescent handlers") {
+    val intMaxLattice = new Lattice[Int] {
+      def join(current: Int, next: Int) = math.max(current, next)
+      def empty = 0
+    }
+    val key = new lattice.DefaultKey[Int]
+
+    val pool = new HandlerPool
+    val completer = CellCompleter[key.type, Int](pool, key)(intMaxLattice)
+
+    pool.execute{() =>
+      throw new Exception(
+        "Even if this happens, quiescent handlers should still run.")
+    }
+
+    try {
+      Await.result(pool.quiescentIncompleteCells, 1.seconds)
+    } catch {
+      case _: java.util.concurrent.TimeoutException => assert(false)
+    }
+
+    pool.shutdown()
+  }
+
   /*test("ImmutabilityAnalysis: Concurrency") {
     val file = new File("lib")
     val lib = Project(file)


### PR DESCRIPTION
Bug fix:
The last running task in a `HandlerPool` is responsible for running quiescent-handlers (see `pool.execute(task: Runnable)`). However, if the last running task throws an exception it will not run the handlers. This will cause any code waiting for the handlers to run (e.g. awaiting `quiescentIncompleteCells`) to wait forever.