### PR TITLE
Enable specifying handler for unhandled exceptions in HandlerPool

### DIFF
--- a/core/src/main/scala/cell/HandlerPool.scala
+++ b/core/src/main/scala/cell/HandlerPool.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.ForkJoinPool
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.annotation.tailrec
+import scala.util.control.NonFatal
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -168,8 +169,8 @@ class HandlerPool(parallelism: Int = 8, unhandledExceptionHandler: Throwable => 
         try {
           task.run()
         } catch {
-          case t: Throwable =>
-            unhandledExceptionHandler(t)
+          case NonFatal(e) =>
+            unhandledExceptionHandler(e)
         } finally {
           var success = false
           var handlersToRun: Option[List[() => Unit]] = None

--- a/core/src/main/scala/cell/HandlerPool.scala
+++ b/core/src/main/scala/cell/HandlerPool.scala
@@ -20,7 +20,7 @@ class PoolState(val handlers: List[() => Unit] = List(), val submittedTasks: Int
     submittedTasks == 0
 }
 
-class HandlerPool(parallelism: Int = 8) {
+class HandlerPool(parallelism: Int = 8, unhandledExceptionHandler: Throwable => Unit = _.printStackTrace()) {
 
   private val pool: ForkJoinPool = new ForkJoinPool(parallelism)
 
@@ -167,6 +167,9 @@ class HandlerPool(parallelism: Int = 8) {
       def run(): Unit = {
         try {
           task.run()
+        } catch {
+          case t: Throwable =>
+            unhandledExceptionHandler(t)
         } finally {
           var success = false
           var handlersToRun: Option[List[() => Unit]] = None

--- a/core/src/test/scala/cell/base.scala
+++ b/core/src/test/scala/cell/base.scala
@@ -921,7 +921,7 @@ class BaseSuite extends FunSuite {
     }
     val key = new lattice.DefaultKey[Int]
 
-    val pool = new HandlerPool
+    val pool = new HandlerPool(unhandledExceptionHandler = { t => /* do nothing */ })
     val completer = CellCompleter[key.type, Int](pool, key)(intMaxLattice)
 
     pool.execute { () =>


### PR DESCRIPTION
This also fixes an issue with a test case which caused the output
of a spurious exception stack trace.