### PR TITLE
Redefine whenNext

### DIFF
--- a/core/src/main/scala/cell/Cell.scala
+++ b/core/src/main/scala/cell/Cell.scala
@@ -16,14 +16,12 @@ import lattice.{ Lattice, LatticeViolationException, Key, DefaultKey }
 //case object WhenNextComplete extends WhenNextPredicate
 //case object FalsePred extends WhenNextPredicate
 
-sealed class WhenNextOutcome[V]
-case class NextOutcome[V](x: V) extends WhenNextOutcome[V]
-case class FinalOutcome[V](x: V) extends WhenNextOutcome[V]
-case class NoOutcome() extends WhenNextOutcome[Nothing]
-
+sealed class WhenNextOutcome[+V]
+case class NextOutcome[+V](x: V) extends WhenNextOutcome[V]
+case class FinalOutcome[+V](x: V) extends WhenNextOutcome[V]
+case object NoOutcome extends WhenNextOutcome[Nothing]
 
 trait Cell[K <: Key[V], V] {
-  Option
   def key: K
 
   /**
@@ -71,7 +69,7 @@ trait Cell[K <: Key[V], V] {
   def waitUntilNoDeps(): Unit
   def waitUntilNoNextDeps(): Unit
 
-  private[cell] def numNextDependencies: Int
+  private[cell] def numDependencies: Int
 
   private[cell] def numNextCallbacks: Int
   private[cell] def numCompleteCallbacks: Int
@@ -217,7 +215,7 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
         pre.asInstanceOf[State[K, V]]
     }
 
-  override def numNextDependencies: Int = {
+  override def numDependencies: Int = {
     val current = currentState()
     if (current == null) 0
     else current.nextDeps.values.flatten.size

--- a/core/src/main/scala/cell/Cell.scala
+++ b/core/src/main/scala/cell/Cell.scala
@@ -558,11 +558,11 @@ private class NextDepRunnable[K <: Key[V], V](
   val pred: V => WhenNextPredicate,
   val shortCutValueCallback: (V, Boolean) => Option[V],
   val completer: CellCompleter[K, V]) // this
-  extends Runnable with OnCompleteRunnable with (Try[V] => Unit) {
+  extends Runnable with OnCompleteRunnable with ((Try[V], Boolean) => Unit) {
   var value: Try[V] = null
   var isFinal = false
 
-  override def apply(x: Try[V]): Unit = {
+  override def apply(x: Try[V], isFinal: Boolean): Unit = {
     x match {
       case Success(v) =>
         pred(v) match {
@@ -584,7 +584,7 @@ private class NextDepRunnable[K <: Key[V], V](
   }
 
   override def run(): Unit = {
-    try apply(value) catch { case NonFatal(e) => pool reportFailure e }
+    try apply(value, isFinal) catch { case NonFatal(e) => pool reportFailure e }
   }
 
   def executeWithValue(v: Try[V], vIsFinal: Boolean): Unit = {

--- a/core/src/main/scala/cell/Cell.scala
+++ b/core/src/main/scala/cell/Cell.scala
@@ -34,33 +34,19 @@ trait Cell[K <: Key[V], V] {
    * Adds a dependency on some `other` cell.
    *
    * Example:
-   *   whenComplete(cell, x => !x, Impure) // if `cell` is completed and the predicate is true (meaning
-   *                                       // `cell` is impure), `this` cell can be completed with constant `Impure`
-   *
-   * @param other  Cell that `this` Cell depends on.
-   * @param pred   Predicate used to decide whether a final result of `this` Cell can be computed early.
-   *               `pred` is applied to value of `other` cell.
-   * @param value  Early result value.
-   */
-  def whenComplete(other: Cell[K, V], pred: V => Boolean, value: V): Unit
-  def whenComplete(other: Cell[K, V], pred: V => Boolean, valueCallback: V => Option[V]): Unit
-
-  /**
-   * Adds a dependency on some `other` cell.
-   *
-   * Example:
-   *   whenNext(cell, x => !x, Impure) // if a preliminary result is put in `cell` using
-   *                                   // `putNext`and the predicate is true (meaning `cell`
+   *   whenNext(cell, x => !x, _ => Impure)
+   *                                   // if a preliminary result is put in `cell` using
+   *                                   // `putNext`, `putFinal` or `put` and the predicate is true (meaning `cell`
    *                                   // is impure), `this`cell can receive next intermediate
    *                                   // result with constant `Impure`
    *
    * @param other  Cell that `this` Cell depends on.
    * @param pred   Predicate used to decide whether an intermediate or final result of `this` Cell can be computed early, depending on what the predicate returns.
    *               `pred` is applied to value of `other` cell.
-   * @param value  Early result value.
+   * @param valueCallback  Callback, that retursn the early result value. It receives the new value of `other` and a boolean value to indicate, if this value is final.
    */
-  def whenNext(other: Cell[K, V], pred: V => WhenNextPredicate, value: V): Unit
-  def whenNext(other: Cell[K, V], pred: V => WhenNextPredicate, valueCallback: V => Option[V]): Unit
+
+  def whenNext(other: Cell[K, V], pred: V => WhenNextPredicate, valueCallback: (V, Boolean) => Option[V]): Unit
 
   def zipFinal(that: Cell[K, V]): Cell[DefaultKey[(V, V)], (V, V)]
 
@@ -73,7 +59,7 @@ trait Cell[K <: Key[V], V] {
   // internal API
 
   // Schedules execution of `callback` when next intermediate result is available.
-  def onNext[U](callback: Try[V] => U): Unit //(implicit context: ExecutionContext): Unit
+  def onNext[U](callback: (Try[V], Boolean) => U): Unit //(implicit context: ExecutionContext): Unit
 
   // Schedules execution of `callback` when completed with final result.
   def onComplete[U](callback: Try[V] => U): Unit
@@ -89,7 +75,7 @@ trait Cell[K <: Key[V], V] {
   private[cell] def numCompleteCallbacks: Int
 
   private[cell] def addCallback[U](callback: Try[V] => U, cell: Cell[K, V]): Unit
-  private[cell] def addNextCallback[U](callback: Try[V] => U, cell: Cell[K, V]): Unit
+  private[cell] def addNextCallback[U](callback: (Try[V], Boolean) => U, cell: Cell[K, V]): Unit
 
   private[cell] def resolveWithValue(value: V): Unit
   private[cell] def cellDependencies: Seq[Cell[K, V]]
@@ -148,14 +134,13 @@ object Cell {
  */
 private class State[K <: Key[V], V](
   val res: V,
-  val deps: Map[Cell[K, V], List[CompleteDepRunnable[K, V]]],
   val callbacks: Map[Cell[K, V], List[CompleteCallbackRunnable[K, V]]],
   val nextDeps: Map[Cell[K, V], List[NextDepRunnable[K, V]]],
   val nextCallbacks: Map[Cell[K, V], List[NextCallbackRunnable[K, V]]])
 
 private object State {
   def empty[K <: Key[V], V](lattice: Lattice[V]): State[K, V] =
-    new State[K, V](lattice.empty, Map(), Map(), Map(), Map())
+    new State[K, V](lattice.empty, Map(), Map(), Map())
 }
 
 class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V]) extends Cell[K, V] with CellCompleter[K, V] {
@@ -231,22 +216,10 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
         pre.asInstanceOf[State[K, V]]
     }
 
-  override def numCompleteDependencies: Int = {
-    val current = currentState()
-    if (current == null) 0
-    else current.deps.values.flatten.size
-  }
-
   override def numNextDependencies: Int = {
     val current = currentState()
     if (current == null) 0
     else current.nextDeps.values.flatten.size
-  }
-
-  override def numTotalDependencies: Int = {
-    val current = currentState()
-    if (current == null) 0
-    (current.deps.values.flatten ++ current.nextDeps.values.flatten).size
   }
 
   override private[cell] def cellDependencies: Seq[Cell[K, V]] = {
@@ -255,17 +228,7 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
         Seq[Cell[K, V]]()
       case pre: State[_, _] => // not completed
         val current = pre.asInstanceOf[State[K, V]]
-        current.deps.keys.toSeq
-    }
-  }
-
-  override private[cell] def totalCellDependencies: Seq[Cell[K, V]] = {
-    state.get() match {
-      case finalRes: Try[_] => // completed with final result
-        Seq[Cell[K, V]]()
-      case pre: State[_, _] => // not completed
-        val current = pre.asInstanceOf[State[K, V]]
-        current.deps.keys.toSeq ++ current.nextDeps.keys.toSeq
+        current.nextDeps.keys.toSeq
     }
   }
 
@@ -295,19 +258,6 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
   /**
    * Adds dependency on `other` cell: when `other` cell receives an intermediate result by using
    *  `putNext`, evaluate `pred` with the result of `other`. If this evaluation yields `WhenNext`
-   *  or `WhenNextComplete`, `this` cell receives an intermediate or a final result `value`
-   *  respectively.
-   *
-   *  The thereby introduced dependency is removed when `this` cell
-   *  is completed (either prior or after an invocation of `whenNext`).
-   */
-  override def whenNext(other: Cell[K, V], pred: V => WhenNextPredicate, value: V): Unit = {
-    whenNext(other, pred, (v: V) => Some(value))
-  }
-
-  /**
-   * Adds dependency on `other` cell: when `other` cell receives an intermediate result by using
-   *  `putNext`, evaluate `pred` with the result of `other`. If this evaluation yields `WhenNext`
    *  or `WhenNextComplete`, `this` cell receives an intermediate or a final result `v`
    *  respectively. To calculate `v`, the `valueCallback` function is called with the result of `other`.
    *
@@ -317,7 +267,7 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
    *  The thereby introduced dependency is removed when `this` cell
    *  is completed (either prior or after an invocation of `whenNext`).
    */
-  override def whenNext(other: Cell[K, V], pred: V => WhenNextPredicate, valueCallback: V => Option[V]): Unit = {
+  override def whenNext(other: Cell[K, V], pred: V => WhenNextPredicate, valueCallback: (V, Boolean) => Option[V]): Unit = {
     var success = false
     while (!success) {
       state.get() match {
@@ -332,8 +282,8 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
 
           val current = raw.asInstanceOf[State[K, V]]
           val newState = current.nextDeps.contains(other) match {
-            case true => new State(current.res, current.deps, current.callbacks, current.nextDeps + (other -> (newDep :: current.nextDeps(other))), current.nextCallbacks)
-            case false => new State(current.res, current.deps, current.callbacks, current.nextDeps + (other -> List(newDep)), current.nextCallbacks)
+            case true => new State(current.res, current.callbacks, current.nextDeps + (other -> (newDep :: current.nextDeps(other))), current.nextCallbacks)
+            case false => new State(current.res, current.callbacks, current.nextDeps + (other -> List(newDep)), current.nextCallbacks)
           }
           if (state.compareAndSet(current, newState)) {
             success = true
@@ -343,52 +293,12 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
     }
   }
 
-  /**
-   * Adds dependency on `other` cell: when `other` cell is completed, evaluate `pred`
-   *  with the result of `other`. If this evaluation yields true, complete `this` cell
-   *  with `value`.
-   *
-   *  The thereby introduced dependency is removed when `this` cell
-   *  is completed (either prior or after an invocation of `whenComplete`).
-   */
-  override def whenComplete(other: Cell[K, V], pred: V => Boolean, value: V): Unit = {
-    whenComplete(other, pred, (v: V) => Some(value))
-  }
-
-  /**
-   * Adds dependency on `other` cell: when `other` cell is completed, evaluate `pred`
-   *  with the result of `other`. If this evaluation yields true, complete `this` cell
-   *  with what the function `valueCallback` returns.
-   *
-   *  The thereby introduced dependency is removed when `this` cell
-   *  is completed (either prior or after an invocation of `whenComplete`).
-   */
-  override def whenComplete(other: Cell[K, V], pred: V => Boolean, valueCallback: V => Option[V]): Unit = {
-    state.get() match {
-      case finalRes: Try[_] => // completed with final result
-      // do not add dependency
-      // in fact, do nothing
-
-      case raw: State[_, _] => // not completed
-        val newDep = new CompleteDepRunnable(pool, other, pred, valueCallback, this)
-        // TODO: it looks like `newDep` is wrapped into a CallbackRunnable by `onComplete` -> bad
-        other.addCallback(newDep, this)
-
-        val current = raw.asInstanceOf[State[K, V]]
-        val newState = current.deps.contains(other) match {
-          case true => new State(current.res, current.deps + (other -> (newDep :: current.deps(other))), current.callbacks, current.nextDeps, current.nextCallbacks)
-          case false => new State(current.res, current.deps + (other -> List(newDep)), current.callbacks, current.nextDeps, current.nextCallbacks)
-        }
-        state.compareAndSet(current, newState)
-    }
-  }
-
   override private[cell] def addCallback[U](callback: Try[V] => U, cell: Cell[K, V]): Unit = {
     val runnable = new CompleteCallbackRunnable[K, V](pool, callback, cell)
     dispatchOrAddCallback(runnable)
   }
 
-  override private[cell] def addNextCallback[U](callback: Try[V] => U, cell: Cell[K, V]): Unit = {
+  override private[cell] def addNextCallback[U](callback: (Try[V], Boolean) => U, cell: Cell[K, V]): Unit = {
     val runnable = new NextCallbackRunnable[K, V](pool, callback, cell)
     dispatchOrAddNextCallback(runnable)
   }
@@ -426,13 +336,13 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
         val current = raw.asInstanceOf[State[K, V]]
         val newVal = tryJoin(current.res, value)
         if (current.res != newVal) {
-          val newState = new State(newVal, current.deps, current.callbacks, current.nextDeps, current.nextCallbacks)
+          val newState = new State(newVal, current.callbacks, current.nextDeps, current.nextCallbacks)
           if (!state.compareAndSet(current, newState)) {
             tryNewState(value)
           } else {
-            // CAS was successful, so there was a point in time where `newVal` was in the cell
+            // CAS was successful, so there was a point in time where `newVal` was in the cell. `newVal` has not been final, as it has been set via `putNext`.
             current.nextCallbacks.values.foreach { callbacks =>
-              callbacks.foreach(callback => callback.executeWithValue(Success(newVal)))
+              callbacks.foreach(callback => callback.executeWithValue(Success(newVal), false))
             }
             true
           }
@@ -470,28 +380,16 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
         res
 
       case (pre: State[K, V], newVal: Try[V]) =>
-        val depsCells = pre.deps.keys
+        val depsCells = pre.nextDeps.keys
         val nextDepsCells = pre.nextDeps.keys
-        if (pre.callbacks.isEmpty) {
-          pre.nextCallbacks.values.foreach { callbacks =>
-            callbacks.foreach(callback => callback.executeWithValue(newVal))
-          }
-        } else {
-          // onNext callbacks with these cells should not be triggered, because they have
-          // onComplete callbacks which are triggered instead.
-          pre.callbacks.values.foreach { callbacks =>
-            callbacks.foreach(callback => callback.executeWithValue(newVal))
-          }
-          pre.nextCallbacks.values.foreach { callbacks =>
-            callbacks.foreach { callback =>
-              if (!pre.callbacks.contains(callback.dependee))
-                callback.executeWithValue(newVal)
-            }
-          }
+
+        pre.callbacks.values.foreach { callbacks =>
+          callbacks.foreach(callback => callback.executeWithValue(newVal))
+        }
+        pre.nextCallbacks.values.foreach { callbacks =>
+          callbacks.foreach(callback => callback.executeWithValue(newVal, true))
         }
 
-        if (depsCells.nonEmpty)
-          depsCells.foreach(_.removeCompleteCallbacks(this))
         if (nextDepsCells.nonEmpty)
           nextDepsCells.foreach(_.removeNextCallbacks(this))
 
@@ -504,30 +402,13 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
   }
 
   @tailrec
-  override private[cell] final def removeDep(cell: Cell[K, V]): Unit = {
-    state.get() match {
-      case pre: State[_, _] =>
-        val current = pre.asInstanceOf[State[K, V]]
-        val newDeps = current.deps - cell
-
-        val newState = new State(current.res, newDeps, current.callbacks, current.nextDeps, current.nextCallbacks)
-        if (!state.compareAndSet(current, newState))
-          removeDep(cell)
-        else if (newDeps.isEmpty)
-          nodepslatch.countDown()
-
-      case _ => /* do nothing */
-    }
-  }
-
-  @tailrec
   override private[cell] final def removeNextDep(cell: Cell[K, V]): Unit = {
     state.get() match {
       case pre: State[_, _] =>
         val current = pre.asInstanceOf[State[K, V]]
         val newNextDeps = current.nextDeps - cell
 
-        val newState = new State(current.res, current.deps, current.callbacks, newNextDeps, current.nextCallbacks)
+        val newState = new State(current.res, current.callbacks, newNextDeps, current.nextCallbacks)
         if (!state.compareAndSet(current, newState))
           removeNextDep(cell)
         else if (newNextDeps.isEmpty)
@@ -544,7 +425,7 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
         val current = pre.asInstanceOf[State[K, V]]
         val newCompleteCallbacks = current.callbacks - cell
 
-        val newState = new State(current.res, current.deps, newCompleteCallbacks, current.nextDeps, current.nextCallbacks)
+        val newState = new State(current.res, newCompleteCallbacks, current.nextDeps, current.nextCallbacks)
         if (!state.compareAndSet(current, newState))
           removeCompleteCallbacks(cell)
       case _ => /* do nothing */
@@ -558,7 +439,7 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
         val current = pre.asInstanceOf[State[K, V]]
         val newNextCallbacks = current.nextCallbacks - cell
 
-        val newState = new State(current.res, current.deps, current.callbacks, current.nextDeps, newNextCallbacks)
+        val newState = new State(current.res, current.callbacks, current.nextDeps, newNextCallbacks)
         if (!state.compareAndSet(current, newState))
           removeNextCallbacks(cell)
       case _ => /* do nothing */
@@ -574,7 +455,7 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
   }
 
   // Schedules execution of `callback` when next intermediate result is available.
-  override def onNext[U](callback: Try[V] => U): Unit = {
+  override def onNext[U](callback: (Try[V], Boolean) => U): Unit = {
     val runnable = new NextCallbackRunnable[K, V](pool, callback, this)
     dispatchOrAddNextCallback(runnable)
   }
@@ -599,8 +480,8 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
         // assemble new state
         val current = pre.asInstanceOf[State[K, V]]
         val newState = current.callbacks.contains(runnable.cell) match {
-          case true => new State(current.res, current.deps, current.callbacks + (runnable.cell -> (runnable :: current.callbacks(runnable.cell))), current.nextDeps, current.nextCallbacks)
-          case false => new State(current.res, current.deps, current.callbacks + (runnable.cell -> List(runnable)), current.nextDeps, current.nextCallbacks)
+          case true => new State(current.res, current.callbacks + (runnable.cell -> (runnable :: current.callbacks(runnable.cell))), current.nextDeps, current.nextCallbacks)
+          case false => new State(current.res, current.callbacks + (runnable.cell -> List(runnable)), current.nextDeps, current.nextCallbacks)
         }
         if (!state.compareAndSet(pre, newState)) dispatchOrAddCallback(runnable)
     }
@@ -614,15 +495,15 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
   @tailrec
   private def dispatchOrAddNextCallback(runnable: NextCallbackRunnable[K, V]): Unit = {
     state.get() match {
-      case r: Try[V] => runnable.executeWithValue(r.asInstanceOf[Try[V]])
+      case r: Try[V] => runnable.executeWithValue(r.asInstanceOf[Try[V]], true)
       /* Cell is completed, do nothing emit an onNext callback */
       // case _: DefaultPromise[_] => compressedRoot().dispatchOrAddCallback(runnable)
       case pre: State[_, _] =>
         // assemble new state
         val current = pre.asInstanceOf[State[K, V]]
         val newState = current.nextCallbacks.contains(runnable.dependee) match {
-          case true => new State(current.res, current.deps, current.callbacks, current.nextDeps, current.nextCallbacks + (runnable.dependee -> (runnable :: current.nextCallbacks(runnable.dependee))))
-          case false => new State(current.res, current.deps, current.callbacks, current.nextDeps, current.nextCallbacks + (runnable.dependee -> List(runnable)))
+          case true => new State(current.res, current.callbacks, current.nextDeps, current.nextCallbacks + (runnable.dependee -> (runnable :: current.nextCallbacks(runnable.dependee))))
+          case false => new State(current.res, current.callbacks, current.nextDeps, current.nextCallbacks + (runnable.dependee -> List(runnable)))
         }
         if (!state.compareAndSet(pre, newState)) dispatchOrAddNextCallback(runnable)
     }
@@ -643,42 +524,6 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
     case t => Failure(t)
   }
 
-}
-
-private class CompleteDepRunnable[K <: Key[V], V](
-  val pool: HandlerPool,
-  val cell: Cell[K, V],
-  val pred: V => Boolean,
-  val shortCutValueCallback: V => Option[V],
-  val completer: CellCompleter[K, V])
-  extends Runnable with OnCompleteRunnable with (Try[V] => Unit) {
-  // must be filled in before running it
-  var value: Try[V] = null
-
-  override def apply(x: Try[V]): Unit = x match {
-    case Success(v) =>
-      if (pred(v)) {
-        shortCutValueCallback.apply(v) match {
-          case Some(scv) => completer.putFinal(scv)
-          case None => /* do nothing */
-        }
-      } else {
-        completer.removeDep(cell)
-        completer.removeNextDep(cell)
-      }
-    case Failure(e) =>
-      completer.removeDep(cell)
-      completer.removeNextDep(cell)
-  }
-
-  override def run(): Unit = {
-    try apply(value) catch { case NonFatal(e) => pool reportFailure e }
-  }
-
-  def executeWithValue(v: Try[V]): Unit = {
-    value = v
-    try pool.execute(this) catch { case NonFatal(t) => pool reportFailure t }
-  }
 }
 
 // copied from `impl.CallbackRunnable` in Scala core lib.
@@ -711,22 +556,23 @@ private class NextDepRunnable[K <: Key[V], V](
   val pool: HandlerPool,
   val cell: Cell[K, V], // otherCell
   val pred: V => WhenNextPredicate,
-  val shortCutValueCallback: V => Option[V],
+  val shortCutValueCallback: (V, Boolean) => Option[V],
   val completer: CellCompleter[K, V]) // this
   extends Runnable with OnCompleteRunnable with (Try[V] => Unit) {
   var value: Try[V] = null
+  var isFinal = false
 
   override def apply(x: Try[V]): Unit = {
     x match {
       case Success(v) =>
         pred(v) match {
           case WhenNext =>
-            shortCutValueCallback(v) match {
+            shortCutValueCallback(v, isFinal) match {
               case Some(scv) => completer.putNext(scv)
               case None => /* do nothing */
             }
           case WhenNextComplete =>
-            shortCutValueCallback(v) match {
+            shortCutValueCallback(v, isFinal) match {
               case Some(scv) => completer.putFinal(scv)
               case None => /* do nothing */
             }
@@ -741,8 +587,9 @@ private class NextDepRunnable[K <: Key[V], V](
     try apply(value) catch { case NonFatal(e) => pool reportFailure e }
   }
 
-  def executeWithValue(v: Try[V]): Unit = {
+  def executeWithValue(v: Try[V], vIsFinal: Boolean): Unit = {
     value = v
+    isFinal = vIsFinal
     try pool.execute(this) catch { case NonFatal(t) => pool reportFailure t }
   }
 }
@@ -752,10 +599,10 @@ private class NextDepRunnable[K <: Key[V], V](
  * @param onNext   Callback function that is triggered on an onNext event
  * @param dependee The cell that depends on this callback
  */
-private class NextCallbackRunnable[K <: Key[V], V](val executor: HandlerPool, val onNext: Try[V] => Any, val dependee: Cell[K, V]) {
-  def executeWithValue(v: Try[V]): Unit = {
+private class NextCallbackRunnable[K <: Key[V], V](val executor: HandlerPool, val onNext: (Try[V], Boolean) => Any, val dependee: Cell[K, V]) {
+  def executeWithValue(v: Try[V], isFinal: Boolean): Unit = {
     // Note that we cannot prepare the ExecutionContext at this point, since we might
     // already be running on a different thread!
-    try executor.execute(() => { onNext(v); () }) catch { case NonFatal(t) => executor reportFailure t }
+    try executor.execute(() => { onNext(v, isFinal); () }) catch { case NonFatal(t) => executor reportFailure t }
   }
 }

--- a/core/src/main/scala/cell/Cell.scala
+++ b/core/src/main/scala/cell/Cell.scala
@@ -388,7 +388,6 @@ class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: Lattice[V
 
         if (depsCells.nonEmpty)
           depsCells.foreach(_.removeNextCallbacks(this))
-          // XXX Why are only nextCallbacks but not completeCallbacks? I guess this is OK, because c.whenNext(other, …) adds a nextCallback to `other`.
 
         true
     }

--- a/core/src/main/scala/cell/CellCompleter.scala
+++ b/core/src/main/scala/cell/CellCompleter.scala
@@ -21,7 +21,7 @@ trait CellCompleter[K <: Key[V], V] {
   def tryNewState(value: V): Boolean
   def tryComplete(value: Try[V]): Boolean
 
-  private[cell] def removeNextDep(cell: Cell[K, V]): Unit
+  private[cell] def removeDep(cell: Cell[K, V]): Unit
 }
 
 object CellCompleter {

--- a/core/src/main/scala/cell/CellCompleter.scala
+++ b/core/src/main/scala/cell/CellCompleter.scala
@@ -21,7 +21,6 @@ trait CellCompleter[K <: Key[V], V] {
   def tryNewState(value: V): Boolean
   def tryComplete(value: Try[V]): Boolean
 
-  private[cell] def removeDep(cell: Cell[K, V]): Unit
   private[cell] def removeNextDep(cell: Cell[K, V]): Unit
 }
 

--- a/core/src/main/scala/cell/HandlerPool.scala
+++ b/core/src/main/scala/cell/HandlerPool.scala
@@ -87,7 +87,7 @@ class HandlerPool(parallelism: Int = 8, unhandledExceptionHandler: Throwable => 
       val registered: Seq[Cell[K, V]] = this.cellsNotDone.get().values.asInstanceOf[Iterable[Cell[K, V]]].toSeq
       println(registered.size)
       if (registered.nonEmpty) {
-        val cSCCs = closedSCCs(registered, (cell: Cell[K, V]) => cell.totalCellDependencies)
+        val cSCCs = closedSCCs(registered, (cell: Cell[K, V]) => cell.cellDependencies)
         cSCCs.foreach(cSCC => resolveCycle(cSCC.asInstanceOf[Seq[Cell[K, V]]]))
       }
       p.success(true)
@@ -114,7 +114,7 @@ class HandlerPool(parallelism: Int = 8, unhandledExceptionHandler: Throwable => 
       // Find one closed strongly connected component (cell)
       val registered: Seq[Cell[K, V]] = this.cellsNotDone.get().values.asInstanceOf[Iterable[Cell[K, V]]].toSeq
       if (registered.nonEmpty) {
-        val cSCCs = closedSCCs(registered, (cell: Cell[K, V]) => cell.totalCellDependencies)
+        val cSCCs = closedSCCs(registered, (cell: Cell[K, V]) => cell.cellDependencies)
         cSCCs.foreach(cSCC => resolveCycle(cSCC.asInstanceOf[Seq[Cell[K, V]]]))
       }
       // Finds the rest of the unresolved cells

--- a/core/src/main/scala/opal/ImmutabilityAnalysis.scala
+++ b/core/src/main/scala/opal/ImmutabilityAnalysis.scala
@@ -1,343 +1,341 @@
-package opal
-
-import java.net.URL
-
-import org.opalj.fpcf._
-
-import scala.collection.JavaConverters._
-
-import scala.concurrent.Await
-import scala.concurrent.duration._
-
-import cell._
-import org.opalj.br.{ Field, ClassFile, ObjectType }
-import org.opalj.br.analyses.{ BasicReport, DefaultOneStepAnalysis, Project, PropertyStoreKey }
-import org.opalj.br.analyses.TypeExtensibilityKey
-import org.opalj.fpcf.analyses.FieldMutabilityAnalysis
-import org.opalj.fpcf.properties.FieldMutability
-
-object ImmutabilityAnalysis extends DefaultOneStepAnalysis {
-
-  override def doAnalyze(
-    project: Project[URL],
-    parameters: Seq[String] = List.empty,
-    isInterrupted: () ⇒ Boolean): BasicReport = {
-    // Run ClassExtensibilityAnalysis
-    val projectStore = project.get(PropertyStoreKey)
-    val manager = project.get(FPCFAnalysesManagerKey)
-    //manager.runAll(
-    //FieldMutabilityAnalysis
-    // REPLACED                ObjectImmutabilityAnalysis
-    // REPLACED                TypeImmutabilityAnalysis
-    //)
-
-    val startTime = System.currentTimeMillis // Used for measuring execution time
-
-    // 1. Initialization of key data structures (two cell(completer) per class file)
-    // One for Object Immutability and one for Type Immutability.
-    val pool = new HandlerPool()
-
-    // classFileToObjectTypeCellCompleter._1 = ObjectImmutability
-    // classFileToObjectTypeCellCompleter._2 = TypeImmutability
-    var classFileToObjectTypeCellCompleter =
-      Map.empty[ClassFile, (CellCompleter[ImmutabilityKey.type, Immutability], CellCompleter[ImmutabilityKey.type, Immutability])]
-    for {
-      classFile <- project.allProjectClassFiles
-    } {
-      val cellCompleter1 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
-      val cellCompleter2 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
-      classFileToObjectTypeCellCompleter = classFileToObjectTypeCellCompleter + ((classFile, (cellCompleter1, cellCompleter2)))
-    }
-
-    val middleTime = System.currentTimeMillis
-
-    // java.lang.Object is by definition immutable
-    val objectClassFileOption = project.classFile(ObjectType.Object)
-    objectClassFileOption.foreach { cf =>
-      classFileToObjectTypeCellCompleter(cf)._1.putFinal(Immutable)
-      classFileToObjectTypeCellCompleter(cf)._2.putFinal(Mutable)
-    }
-
-    // All interfaces are by definition immutable
-    val allInterfaces = project.allProjectClassFiles.par.filter(cf => cf.isInterfaceDeclaration).toList
-    allInterfaces.foreach(cf => classFileToObjectTypeCellCompleter(cf)._1.putFinal(Immutable))
-
-    val classHierarchy = project.classHierarchy
-    import classHierarchy.allSubtypes
-    import classHierarchy.rootTypes
-    import classHierarchy.isInterface
-    // All classes that do not have complete superclass information are mutable
-    // due to the lack of knowledge.
-    val typesForWhichItMayBePossibleToComputeTheMutability = allSubtypes(ObjectType.Object, reflexive = true)
-    val unexpectedRootTypes = rootTypes.filter(rt ⇒ (rt ne ObjectType.Object) && !isInterface(rt).isNo)
-    unexpectedRootTypes.map(rt ⇒ allSubtypes(rt, reflexive = true)).flatten.view.
-      filter(ot ⇒ !typesForWhichItMayBePossibleToComputeTheMutability.contains(ot)).
-      foreach(ot ⇒ project.classFile(ot) foreach { cf ⇒
-        classFileToObjectTypeCellCompleter(cf)._1.putFinal(Mutable)
-      })
-
-    // 2. trigger analyses
-    for {
-      classFile <- project.allProjectClassFiles.par
-    } {
-      pool.execute(() => {
-        if (!classFileToObjectTypeCellCompleter(classFile)._1.cell.isComplete)
-          objectImmutabilityAnalysis(project, classFileToObjectTypeCellCompleter, manager, classFile)
-      })
-      pool.execute(() => {
-        if (!classFileToObjectTypeCellCompleter(classFile)._2.cell.isComplete)
-          typeImmutabilityAnalysis(project, classFileToObjectTypeCellCompleter, manager, classFile)
-      })
-    }
-    pool.whileQuiescentResolveDefault
-    pool.shutdown()
-
-    val endTime = System.currentTimeMillis
-
-    val setupTime = middleTime - startTime
-    val analysisTime = endTime - middleTime
-    val combinedTime = endTime - startTime
-
-    /* Fixes the results so the output looks good */
-    val resultClassFiles = project.allProjectClassFiles.par.filter(!allInterfaces.contains(_))
-    val mutableClassFilesInfo = for {
-      cf <- resultClassFiles if (classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() == Mutable)
-    } yield (cf.thisType.toJava + " => " +
-      classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() + "Object => " +
-      classFileToObjectTypeCellCompleter(cf)._2.cell.getResult() + "Type")
-
-    val immutableClassFilesInfo = for {
-      cf <- resultClassFiles if (classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() == Immutable)
-    } yield (cf.thisType.toJava + " => " +
-      classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() + "Object => " +
-      classFileToObjectTypeCellCompleter(cf)._2.cell.getResult() + "Type")
-
-    val conditionallyImmutableClassFilesInfo = for {
-      cf <- resultClassFiles if (classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() == ConditionallyImmutable)
-    } yield (cf.thisType.toJava + " => " +
-      classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() + "Object => " +
-      classFileToObjectTypeCellCompleter(cf)._2.cell.getResult() + "Type")
-
-    val sortedClassFilesInfo = (immutableClassFilesInfo.toList.sorted ++
-      conditionallyImmutableClassFilesInfo.toList.sorted ++ mutableClassFilesInfo.toList.sorted)
-    BasicReport(sortedClassFilesInfo.mkString("\n") +
-      s"\nSETUP TIME: $setupTime" +
-      s"\nANALYIS TIME: $analysisTime" +
-      s"\nCOMBINED TIME: $combinedTime")
-  }
-
-  /**
-   * This function is used for the tests, to not run the external analyses several times.
-   *
-   * @param project
-   * @param manager
-   * @return
-   */
-  def analyzeWithoutClassExtensibilityAndFieldMutabilityAnalysis(
-    project: Project[URL],
-    manager: FPCFAnalysesManager): BasicReport = {
-    // 1. Initialization of key data structures (two cell(completer) per class file)
-    // One for Object Immutability and one for Type Immutability.
-    val pool = new HandlerPool()
-
-    // classFileToObjectTypeCellCompleter._1 = ObjectImmutability
-    // classFileToObjectTypeCellCompleter._2 = TypeImmutability
-    var classFileToObjectTypeCellCompleter =
-      Map.empty[ClassFile, (CellCompleter[ImmutabilityKey.type, Immutability], CellCompleter[ImmutabilityKey.type, Immutability])]
-    for {
-      classFile <- project.allProjectClassFiles
-    } {
-      val cellCompleter1 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
-      val cellCompleter2 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
-      classFileToObjectTypeCellCompleter = classFileToObjectTypeCellCompleter + ((classFile, (cellCompleter1, cellCompleter2)))
-    }
-
-    // java.lang.Object is by definition immutable
-    val objectClassFileOption = project.classFile(ObjectType.Object)
-    objectClassFileOption.foreach { cf =>
-      classFileToObjectTypeCellCompleter(cf)._1.putFinal(Immutable)
-      classFileToObjectTypeCellCompleter(cf)._2.putFinal(Mutable) // Should the TypeImmutability be Mutable?
-    }
-
-    // All interfaces are by definition immutable
-    val allInterfaces = project.allProjectClassFiles.par.filter(cf => cf.isInterfaceDeclaration).toList
-    allInterfaces.foreach(cf => classFileToObjectTypeCellCompleter(cf)._1.putFinal(Immutable))
-
-    val classHierarchy = project.classHierarchy
-    import classHierarchy.allSubtypes
-    import classHierarchy.rootTypes
-    import classHierarchy.isInterface
-    // All classes that do not have complete superclass information are mutable
-    // due to the lack of knowledge.
-    val typesForWhichItMayBePossibleToComputeTheMutability = allSubtypes(ObjectType.Object, reflexive = true)
-    val unexpectedRootTypes = rootTypes.filter(rt ⇒ (rt ne ObjectType.Object) && !isInterface(rt).isNo)
-    unexpectedRootTypes.map(rt ⇒ allSubtypes(rt, reflexive = true)).flatten.view.
-      filter(ot ⇒ !typesForWhichItMayBePossibleToComputeTheMutability.contains(ot)).
-      foreach(ot ⇒ project.classFile(ot) foreach { cf ⇒
-        classFileToObjectTypeCellCompleter(cf)._1.putFinal(Mutable)
-      })
-
-    // 2. trigger analyses
-    for {
-      classFile <- project.allProjectClassFiles.par
-    } {
-      pool.execute(() => {
-        if (!classFileToObjectTypeCellCompleter(classFile)._1.cell.isComplete)
-          objectImmutabilityAnalysis(project, classFileToObjectTypeCellCompleter, manager, classFile)
-      })
-      pool.execute(() => {
-        if (!classFileToObjectTypeCellCompleter(classFile)._2.cell.isComplete)
-          typeImmutabilityAnalysis(project, classFileToObjectTypeCellCompleter, manager, classFile)
-      })
-    }
-    pool.whileQuiescentResolveCell
-    pool.shutdown()
-
-    /* Fixes the results so the output looks good */
-    val mutableClassFilesInfo = for {
-      (cf, (objImmutability, typeImmutability)) <- classFileToObjectTypeCellCompleter if (objImmutability.cell.getResult() == Mutable)
-    } yield (cf.thisType.toJava + " => " + objImmutability.cell.getResult() + "Object => " + typeImmutability.cell.getResult() + "Type")
-
-    val immutableClassFilesInfo = for {
-      (cf, (objImmutability, typeImmutability)) <- classFileToObjectTypeCellCompleter if (objImmutability.cell.getResult() == Immutable)
-    } yield (cf.thisType.toJava + " => " + objImmutability.cell.getResult() + "Object => " + typeImmutability.cell.getResult() + "Type")
-
-    val conditionallyImmutableClassFilesInfo = for {
-      (cf, (objImmutability, typeImmutability)) <- classFileToObjectTypeCellCompleter if (objImmutability.cell.getResult() == ConditionallyImmutable)
-    } yield (cf.thisType.toJava + " => " + objImmutability.cell.getResult() + "Object => " + typeImmutability.cell.getResult() + "Type")
-
-    val sortedClassFilesInfo = (immutableClassFilesInfo.toList.sorted ++
-      conditionallyImmutableClassFilesInfo.toList.sorted ++ mutableClassFilesInfo.toList.sorted)
-    BasicReport(sortedClassFilesInfo)
-  }
-
-  /**
-   *  Determines a class files' ObjectImmutability.
-   */
-  def objectImmutabilityAnalysis(
-    project: Project[URL],
-    classFileToObjectTypeCellCompleter: Map[ClassFile, (CellCompleter[ImmutabilityKey.type, Immutability], CellCompleter[ImmutabilityKey.type, Immutability])],
-    manager: FPCFAnalysesManager,
-    cf: ClassFile): Unit = {
-    val cellCompleter = classFileToObjectTypeCellCompleter(cf)._1
-
-    val classHierarchy = project.classHierarchy
-    val directSuperTypes = classHierarchy.directSupertypes(cf.thisType)
-
-    // Check fields to determine ObjectImmutability
-    val nonFinalInstanceFields = cf.fields.collect { case f if !f.isStatic && !f.isFinal => f }
-
-    if (!nonFinalInstanceFields.isEmpty)
-      cellCompleter.putFinal(Mutable)
-
-    // If the cell hasn't already been completed with an ObjectImmutability, then it is
-    // dependent on FieldMutability and its superclasses
-    if (!cellCompleter.cell.isComplete) {
-      if (cf.fields.exists(f => !f.isStatic && f.fieldType.isArrayType))
-        cellCompleter.putNext(ConditionallyImmutable)
-      else {
-        val fieldTypes: Set[ObjectType] =
-          cf.fields.collect {
-            case f if !f.isStatic && f.fieldType.isObjectType => f.fieldType.asObjectType
-          }.toSet
-
-        val hasUnresolvableDependencies =
-          fieldTypes.exists { t =>
-            project.classFile(t) match {
-              case None => true /* we have an unresolved dependency */
-              case Some(classFile) => false /* do nothing */
-            }
-          }
-
-        if (hasUnresolvableDependencies)
-          cellCompleter.putNext(ConditionallyImmutable)
-        else {
-          val finalInstanceFields = cf.fields.collect { case f if !f.isStatic && f.isFinal => f }
-          finalInstanceFields.foreach { f =>
-            if (f.fieldType.isObjectType) {
-              project.classFile(f.fieldType.asObjectType) match {
-                case Some(classFile) =>
-                  val fieldTypeCell = classFileToObjectTypeCellCompleter(classFile)._2.cell
-                  cellCompleter.cell.whenNext(
-                    fieldTypeCell,
-                    (fieldImm: Immutability) => fieldImm match {
-                      case Mutable | ConditionallyImmutable => WhenNext
-                      case Immutable => FalsePred
-                    },
-                    ConditionallyImmutable)
-                case None => /* Do nothing */
-              }
-            }
-          }
-        }
-      }
-      // Check with superclass to determine ObjectImmutability
-      val directSuperClasses = directSuperTypes.
-        filter(superType => project.classFile(superType) != None).
-        map(superType => project.classFile(superType).get)
-
-      directSuperClasses foreach { superClass =>
-        cellCompleter.cell.whenNext(
-          classFileToObjectTypeCellCompleter(superClass)._1.cell,
-          (imm: Immutability) => imm match {
-            case Immutable => FalsePred
-            case Mutable => WhenNextComplete
-            case ConditionallyImmutable => WhenNext
-          },
-          Some(_))
-      }
-    }
-  }
-
-  /**
-   *  Determines a class files' TypeImmutability.
-   */
-  def typeImmutabilityAnalysis(
-    project: Project[URL],
-    classFileToObjectTypeCellCompleter: Map[ClassFile, (CellCompleter[ImmutabilityKey.type, Immutability], CellCompleter[ImmutabilityKey.type, Immutability])],
-    manager: FPCFAnalysesManager,
-    cf: ClassFile): Unit = {
-    val typeExtensibility = project.get(TypeExtensibilityKey)
-    val cellCompleter = classFileToObjectTypeCellCompleter(cf)._2
-    val isExtensible = typeExtensibility(cf.thisType)
-    if (isExtensible.isYesOrUnknown)
-      cellCompleter.putFinal(Mutable)
-
-    val classHierarchy = project.classHierarchy
-    val directSubtypes = classHierarchy.directSubtypesOf(cf.thisType)
-
-    if (!cellCompleter.cell.isComplete) {
-      // If this class file doesn't have subtypes, then the TypeImmutability is the same as
-      // the ObjectImmutability
-      if (cf.isFinal || directSubtypes.isEmpty) {
-        cellCompleter.cell.whenNext(
-          classFileToObjectTypeCellCompleter(cf)._1.cell,
-          (imm: Immutability) => imm match {
-            case Immutable => FalsePred
-            case Mutable => WhenNextComplete
-            case ConditionallyImmutable => WhenNext
-          },
-          Some(_))
-      } else {
-        val unavailableSubtype = directSubtypes.find(t ⇒ project.classFile(t).isEmpty)
-        if (unavailableSubtype.isDefined)
-          cellCompleter.putFinal(Mutable)
-
-        if (!cellCompleter.cell.isComplete) {
-          // Check subclasses to determine TypeImmutability
-          val directSubclasses = directSubtypes map { subtype ⇒ project.classFile(subtype).get }
-          directSubclasses foreach { subclass =>
-            cellCompleter.cell.whenNext(
-              classFileToObjectTypeCellCompleter(subclass)._2.cell,
-              (imm: Immutability) => imm match {
-                case Immutable => FalsePred
-                case Mutable => WhenNextComplete
-                case ConditionallyImmutable => WhenNext
-              },
-              Some(_))
-          }
-        }
-      }
-    }
-  }
-}
+//package opal
+//
+//import java.net.URL
+//
+//import org.opalj.fpcf._
+//
+//import scala.collection.JavaConverters._
+//
+//import scala.concurrent.Await
+//import scala.concurrent.duration._
+//
+//import cell._
+//import org.opalj.br.{ Field, ClassFile, ObjectType }
+//import org.opalj.br.analyses.{ BasicReport, DefaultOneStepAnalysis, Project, PropertyStoreKey }
+//import org.opalj.br.analyses.TypeExtensibilityKey
+//import org.opalj.fpcf.analyses.FieldMutabilityAnalysis
+//import org.opalj.fpcf.properties.FieldMutability
+//
+//object ImmutabilityAnalysis extends DefaultOneStepAnalysis {
+//
+//  override def doAnalyze(
+//    project: Project[URL],
+//    parameters: Seq[String] = List.empty,
+//    isInterrupted: () ⇒ Boolean): BasicReport = {
+//    // Run ClassExtensibilityAnalysis
+//    val projectStore = project.get(PropertyStoreKey)
+//    val manager = project.get(FPCFAnalysesManagerKey)
+//    //manager.runAll(
+//    //FieldMutabilityAnalysis
+//    // REPLACED                ObjectImmutabilityAnalysis
+//    // REPLACED                TypeImmutabilityAnalysis
+//    //)
+//
+//    val startTime = System.currentTimeMillis // Used for measuring execution time
+//
+//    // 1. Initialization of key data structures (two cell(completer) per class file)
+//    // One for Object Immutability and one for Type Immutability.
+//    val pool = new HandlerPool()
+//
+//    // classFileToObjectTypeCellCompleter._1 = ObjectImmutability
+//    // classFileToObjectTypeCellCompleter._2 = TypeImmutability
+//    var classFileToObjectTypeCellCompleter =
+//      Map.empty[ClassFile, (CellCompleter[ImmutabilityKey.type, Immutability], CellCompleter[ImmutabilityKey.type, Immutability])]
+//    for {
+//      classFile <- project.allProjectClassFiles
+//    } {
+//      val cellCompleter1 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
+//      val cellCompleter2 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
+//      classFileToObjectTypeCellCompleter = classFileToObjectTypeCellCompleter + ((classFile, (cellCompleter1, cellCompleter2)))
+//    }
+//
+//    val middleTime = System.currentTimeMillis
+//
+//    // java.lang.Object is by definition immutable
+//    val objectClassFileOption = project.classFile(ObjectType.Object)
+//    objectClassFileOption.foreach { cf =>
+//      classFileToObjectTypeCellCompleter(cf)._1.putFinal(Immutable)
+//      classFileToObjectTypeCellCompleter(cf)._2.putFinal(Mutable)
+//    }
+//
+//    // All interfaces are by definition immutable
+//    val allInterfaces = project.allProjectClassFiles.par.filter(cf => cf.isInterfaceDeclaration).toList
+//    allInterfaces.foreach(cf => classFileToObjectTypeCellCompleter(cf)._1.putFinal(Immutable))
+//
+//    val classHierarchy = project.classHierarchy
+//    import classHierarchy.allSubtypes
+//    import classHierarchy.rootTypes
+//    import classHierarchy.isInterface
+//    // All classes that do not have complete superclass information are mutable
+//    // due to the lack of knowledge.
+//    val typesForWhichItMayBePossibleToComputeTheMutability = allSubtypes(ObjectType.Object, reflexive = true)
+//    val unexpectedRootTypes = rootTypes.filter(rt ⇒ (rt ne ObjectType.Object) && !isInterface(rt).isNo)
+//    unexpectedRootTypes.map(rt ⇒ allSubtypes(rt, reflexive = true)).flatten.view.
+//      filter(ot ⇒ !typesForWhichItMayBePossibleToComputeTheMutability.contains(ot)).
+//      foreach(ot ⇒ project.classFile(ot) foreach { cf ⇒
+//        classFileToObjectTypeCellCompleter(cf)._1.putFinal(Mutable)
+//      })
+//
+//    // 2. trigger analyses
+//    for {
+//      classFile <- project.allProjectClassFiles.par
+//    } {
+//      pool.execute(() => {
+//        if (!classFileToObjectTypeCellCompleter(classFile)._1.cell.isComplete)
+//          objectImmutabilityAnalysis(project, classFileToObjectTypeCellCompleter, manager, classFile)
+//      })
+//      pool.execute(() => {
+//        if (!classFileToObjectTypeCellCompleter(classFile)._2.cell.isComplete)
+//          typeImmutabilityAnalysis(project, classFileToObjectTypeCellCompleter, manager, classFile)
+//      })
+//    }
+//    pool.whileQuiescentResolveDefault
+//    pool.shutdown()
+//
+//    val endTime = System.currentTimeMillis
+//
+//    val setupTime = middleTime - startTime
+//    val analysisTime = endTime - middleTime
+//    val combinedTime = endTime - startTime
+//
+//    /* Fixes the results so the output looks good */
+//    val resultClassFiles = project.allProjectClassFiles.par.filter(!allInterfaces.contains(_))
+//    val mutableClassFilesInfo = for {
+//      cf <- resultClassFiles if (classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() == Mutable)
+//    } yield (cf.thisType.toJava + " => " +
+//      classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() + "Object => " +
+//      classFileToObjectTypeCellCompleter(cf)._2.cell.getResult() + "Type")
+//
+//    val immutableClassFilesInfo = for {
+//      cf <- resultClassFiles if (classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() == Immutable)
+//    } yield (cf.thisType.toJava + " => " +
+//      classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() + "Object => " +
+//      classFileToObjectTypeCellCompleter(cf)._2.cell.getResult() + "Type")
+//
+//    val conditionallyImmutableClassFilesInfo = for {
+//      cf <- resultClassFiles if (classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() == ConditionallyImmutable)
+//    } yield (cf.thisType.toJava + " => " +
+//      classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() + "Object => " +
+//      classFileToObjectTypeCellCompleter(cf)._2.cell.getResult() + "Type")
+//
+//    val sortedClassFilesInfo = (immutableClassFilesInfo.toList.sorted ++
+//      conditionallyImmutableClassFilesInfo.toList.sorted ++ mutableClassFilesInfo.toList.sorted)
+//    BasicReport(sortedClassFilesInfo.mkString("\n") +
+//      s"\nSETUP TIME: $setupTime" +
+//      s"\nANALYIS TIME: $analysisTime" +
+//      s"\nCOMBINED TIME: $combinedTime")
+//  }
+//
+//  /**
+//   * This function is used for the tests, to not run the external analyses several times.
+//   *
+//   * @param project
+//   * @param manager
+//   * @return
+//   */
+//  def analyzeWithoutClassExtensibilityAndFieldMutabilityAnalysis(
+//    project: Project[URL],
+//    manager: FPCFAnalysesManager): BasicReport = {
+//    // 1. Initialization of key data structures (two cell(completer) per class file)
+//    // One for Object Immutability and one for Type Immutability.
+//    val pool = new HandlerPool()
+//
+//    // classFileToObjectTypeCellCompleter._1 = ObjectImmutability
+//    // classFileToObjectTypeCellCompleter._2 = TypeImmutability
+//    var classFileToObjectTypeCellCompleter =
+//      Map.empty[ClassFile, (CellCompleter[ImmutabilityKey.type, Immutability], CellCompleter[ImmutabilityKey.type, Immutability])]
+//    for {
+//      classFile <- project.allProjectClassFiles
+//    } {
+//      val cellCompleter1 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
+//      val cellCompleter2 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
+//      classFileToObjectTypeCellCompleter = classFileToObjectTypeCellCompleter + ((classFile, (cellCompleter1, cellCompleter2)))
+//    }
+//
+//    // java.lang.Object is by definition immutable
+//    val objectClassFileOption = project.classFile(ObjectType.Object)
+//    objectClassFileOption.foreach { cf =>
+//      classFileToObjectTypeCellCompleter(cf)._1.putFinal(Immutable)
+//      classFileToObjectTypeCellCompleter(cf)._2.putFinal(Mutable) // Should the TypeImmutability be Mutable?
+//    }
+//
+//    // All interfaces are by definition immutable
+//    val allInterfaces = project.allProjectClassFiles.par.filter(cf => cf.isInterfaceDeclaration).toList
+//    allInterfaces.foreach(cf => classFileToObjectTypeCellCompleter(cf)._1.putFinal(Immutable))
+//
+//    val classHierarchy = project.classHierarchy
+//    import classHierarchy.allSubtypes
+//    import classHierarchy.rootTypes
+//    import classHierarchy.isInterface
+//    // All classes that do not have complete superclass information are mutable
+//    // due to the lack of knowledge.
+//    val typesForWhichItMayBePossibleToComputeTheMutability = allSubtypes(ObjectType.Object, reflexive = true)
+//    val unexpectedRootTypes = rootTypes.filter(rt ⇒ (rt ne ObjectType.Object) && !isInterface(rt).isNo)
+//    unexpectedRootTypes.map(rt ⇒ allSubtypes(rt, reflexive = true)).flatten.view.
+//      filter(ot ⇒ !typesForWhichItMayBePossibleToComputeTheMutability.contains(ot)).
+//      foreach(ot ⇒ project.classFile(ot) foreach { cf ⇒
+//        classFileToObjectTypeCellCompleter(cf)._1.putFinal(Mutable)
+//      })
+//
+//    // 2. trigger analyses
+//    for {
+//      classFile <- project.allProjectClassFiles.par
+//    } {
+//      pool.execute(() => {
+//        if (!classFileToObjectTypeCellCompleter(classFile)._1.cell.isComplete)
+//          objectImmutabilityAnalysis(project, classFileToObjectTypeCellCompleter, manager, classFile)
+//      })
+//      pool.execute(() => {
+//        if (!classFileToObjectTypeCellCompleter(classFile)._2.cell.isComplete)
+//          typeImmutabilityAnalysis(project, classFileToObjectTypeCellCompleter, manager, classFile)
+//      })
+//    }
+//    pool.whileQuiescentResolveCell
+//    pool.shutdown()
+//
+//    /* Fixes the results so the output looks good */
+//    val mutableClassFilesInfo = for {
+//      (cf, (objImmutability, typeImmutability)) <- classFileToObjectTypeCellCompleter if (objImmutability.cell.getResult() == Mutable)
+//    } yield (cf.thisType.toJava + " => " + objImmutability.cell.getResult() + "Object => " + typeImmutability.cell.getResult() + "Type")
+//
+//    val immutableClassFilesInfo = for {
+//      (cf, (objImmutability, typeImmutability)) <- classFileToObjectTypeCellCompleter if (objImmutability.cell.getResult() == Immutable)
+//    } yield (cf.thisType.toJava + " => " + objImmutability.cell.getResult() + "Object => " + typeImmutability.cell.getResult() + "Type")
+//
+//    val conditionallyImmutableClassFilesInfo = for {
+//      (cf, (objImmutability, typeImmutability)) <- classFileToObjectTypeCellCompleter if (objImmutability.cell.getResult() == ConditionallyImmutable)
+//    } yield (cf.thisType.toJava + " => " + objImmutability.cell.getResult() + "Object => " + typeImmutability.cell.getResult() + "Type")
+//
+//    val sortedClassFilesInfo = (immutableClassFilesInfo.toList.sorted ++
+//      conditionallyImmutableClassFilesInfo.toList.sorted ++ mutableClassFilesInfo.toList.sorted)
+//    BasicReport(sortedClassFilesInfo)
+//  }
+//
+//  /**
+//   *  Determines a class files' ObjectImmutability.
+//   */
+//  def objectImmutabilityAnalysis(
+//    project: Project[URL],
+//    classFileToObjectTypeCellCompleter: Map[ClassFile, (CellCompleter[ImmutabilityKey.type, Immutability], CellCompleter[ImmutabilityKey.type, Immutability])],
+//    manager: FPCFAnalysesManager,
+//    cf: ClassFile): Unit = {
+//    val cellCompleter = classFileToObjectTypeCellCompleter(cf)._1
+//
+//    val classHierarchy = project.classHierarchy
+//    val directSuperTypes = classHierarchy.directSupertypes(cf.thisType)
+//
+//    // Check fields to determine ObjectImmutability
+//    val nonFinalInstanceFields = cf.fields.collect { case f if !f.isStatic && !f.isFinal => f }
+//
+//    if (!nonFinalInstanceFields.isEmpty)
+//      cellCompleter.putFinal(Mutable)
+//
+//    // If the cell hasn't already been completed with an ObjectImmutability, then it is
+//    // dependent on FieldMutability and its superclasses
+//    if (!cellCompleter.cell.isComplete) {
+//      if (cf.fields.exists(f => !f.isStatic && f.fieldType.isArrayType))
+//        cellCompleter.putNext(ConditionallyImmutable)
+//      else {
+//        val fieldTypes: Set[ObjectType] =
+//          cf.fields.collect {
+//            case f if !f.isStatic && f.fieldType.isObjectType => f.fieldType.asObjectType
+//          }.toSet
+//
+//        val hasUnresolvableDependencies =
+//          fieldTypes.exists { t =>
+//            project.classFile(t) match {
+//              case None => true /* we have an unresolved dependency */
+//              case Some(classFile) => false /* do nothing */
+//            }
+//          }
+//
+//        if (hasUnresolvableDependencies)
+//          cellCompleter.putNext(ConditionallyImmutable)
+//        else {
+//          val finalInstanceFields = cf.fields.collect { case f if !f.isStatic && f.isFinal => f }
+//          finalInstanceFields.foreach { f =>
+//            if (f.fieldType.isObjectType) {
+//              project.classFile(f.fieldType.asObjectType) match {
+//                case Some(classFile) =>
+//                  val fieldTypeCell = classFileToObjectTypeCellCompleter(classFile)._2.cell
+//                  cellCompleter.cell.whenNext(
+//                    fieldTypeCell,
+//                    (fieldImm: Immutability, _) => fieldImm match {
+//                      case Mutable | ConditionallyImmutable => NextOutcome(ConditionallyImmutable)
+//                      case Immutable => NoOutcome
+//                    })
+//                case None => /* Do nothing */
+//              }
+//            }
+//          }
+//        }
+//      }
+//      // Check with superclass to determine ObjectImmutability
+//      val directSuperClasses = directSuperTypes.
+//        filter(superType => project.classFile(superType) != None).
+//        map(superType => project.classFile(superType).get)
+//
+//      directSuperClasses foreach { superClass =>
+//        cellCompleter.cell.whenNext(
+//          classFileToObjectTypeCellCompleter(superClass)._1.cell,
+//          (imm: Immutability, _) => imm match {
+//            case Immutable => NoOutcome
+//            case Mutable => FinalOutcome(imm)
+//            case ConditionallyImmutable => NextOutcome(imm)
+//          })
+//      }
+//    }
+//  }
+//
+//  /**
+//   *  Determines a class files' TypeImmutability.
+//   */
+//  def typeImmutabilityAnalysis(
+//    project: Project[URL],
+//    classFileToObjectTypeCellCompleter: Map[ClassFile, (CellCompleter[ImmutabilityKey.type, Immutability], CellCompleter[ImmutabilityKey.type, Immutability])],
+//    manager: FPCFAnalysesManager,
+//    cf: ClassFile): Unit = {
+//    val typeExtensibility = project.get(TypeExtensibilityKey)
+//    val cellCompleter = classFileToObjectTypeCellCompleter(cf)._2
+//    val isExtensible = typeExtensibility(cf.thisType)
+//    if (isExtensible.isYesOrUnknown)
+//      cellCompleter.putFinal(Mutable)
+//
+//    val classHierarchy = project.classHierarchy
+//    val directSubtypes = classHierarchy.directSubtypesOf(cf.thisType)
+//
+//    if (!cellCompleter.cell.isComplete) {
+//      // If this class file doesn't have subtypes, then the TypeImmutability is the same as
+//      // the ObjectImmutability
+//      if (cf.isFinal || directSubtypes.isEmpty) {
+//        cellCompleter.cell.whenNext(
+//          classFileToObjectTypeCellCompleter(cf)._1.cell,
+//          (imm: Immutability) => imm match {
+//            case Immutable => FalsePred
+//            case Mutable => WhenNextComplete
+//            case ConditionallyImmutable => WhenNext
+//          },
+//          Some(_))
+//      } else {
+//        val unavailableSubtype = directSubtypes.find(t ⇒ project.classFile(t).isEmpty)
+//        if (unavailableSubtype.isDefined)
+//          cellCompleter.putFinal(Mutable)
+//
+//        if (!cellCompleter.cell.isComplete) {
+//          // Check subclasses to determine TypeImmutability
+//          val directSubclasses = directSubtypes map { subtype ⇒ project.classFile(subtype).get }
+//          directSubclasses foreach { subclass =>
+//            cellCompleter.cell.whenNext(
+//              classFileToObjectTypeCellCompleter(subclass)._2.cell,
+//              (imm: Immutability) => imm match {
+//                case Immutable => FalsePred
+//                case Mutable => WhenNextComplete
+//                case ConditionallyImmutable => WhenNext
+//              },
+//              Some(_))
+//          }
+//        }
+//      }
+//    }
+//  }
+//}

--- a/core/src/main/scala/opal/ImmutabilityAnalysis.scala
+++ b/core/src/main/scala/opal/ImmutabilityAnalysis.scala
@@ -1,341 +1,339 @@
-//package opal
-//
-//import java.net.URL
-//
-//import org.opalj.fpcf._
-//
-//import scala.collection.JavaConverters._
-//
-//import scala.concurrent.Await
-//import scala.concurrent.duration._
-//
-//import cell._
-//import org.opalj.br.{ Field, ClassFile, ObjectType }
-//import org.opalj.br.analyses.{ BasicReport, DefaultOneStepAnalysis, Project, PropertyStoreKey }
-//import org.opalj.br.analyses.TypeExtensibilityKey
-//import org.opalj.fpcf.analyses.FieldMutabilityAnalysis
-//import org.opalj.fpcf.properties.FieldMutability
-//
-//object ImmutabilityAnalysis extends DefaultOneStepAnalysis {
-//
-//  override def doAnalyze(
-//    project: Project[URL],
-//    parameters: Seq[String] = List.empty,
-//    isInterrupted: () ⇒ Boolean): BasicReport = {
-//    // Run ClassExtensibilityAnalysis
-//    val projectStore = project.get(PropertyStoreKey)
-//    val manager = project.get(FPCFAnalysesManagerKey)
-//    //manager.runAll(
-//    //FieldMutabilityAnalysis
-//    // REPLACED                ObjectImmutabilityAnalysis
-//    // REPLACED                TypeImmutabilityAnalysis
-//    //)
-//
-//    val startTime = System.currentTimeMillis // Used for measuring execution time
-//
-//    // 1. Initialization of key data structures (two cell(completer) per class file)
-//    // One for Object Immutability and one for Type Immutability.
-//    val pool = new HandlerPool()
-//
-//    // classFileToObjectTypeCellCompleter._1 = ObjectImmutability
-//    // classFileToObjectTypeCellCompleter._2 = TypeImmutability
-//    var classFileToObjectTypeCellCompleter =
-//      Map.empty[ClassFile, (CellCompleter[ImmutabilityKey.type, Immutability], CellCompleter[ImmutabilityKey.type, Immutability])]
-//    for {
-//      classFile <- project.allProjectClassFiles
-//    } {
-//      val cellCompleter1 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
-//      val cellCompleter2 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
-//      classFileToObjectTypeCellCompleter = classFileToObjectTypeCellCompleter + ((classFile, (cellCompleter1, cellCompleter2)))
-//    }
-//
-//    val middleTime = System.currentTimeMillis
-//
-//    // java.lang.Object is by definition immutable
-//    val objectClassFileOption = project.classFile(ObjectType.Object)
-//    objectClassFileOption.foreach { cf =>
-//      classFileToObjectTypeCellCompleter(cf)._1.putFinal(Immutable)
-//      classFileToObjectTypeCellCompleter(cf)._2.putFinal(Mutable)
-//    }
-//
-//    // All interfaces are by definition immutable
-//    val allInterfaces = project.allProjectClassFiles.par.filter(cf => cf.isInterfaceDeclaration).toList
-//    allInterfaces.foreach(cf => classFileToObjectTypeCellCompleter(cf)._1.putFinal(Immutable))
-//
-//    val classHierarchy = project.classHierarchy
-//    import classHierarchy.allSubtypes
-//    import classHierarchy.rootTypes
-//    import classHierarchy.isInterface
-//    // All classes that do not have complete superclass information are mutable
-//    // due to the lack of knowledge.
-//    val typesForWhichItMayBePossibleToComputeTheMutability = allSubtypes(ObjectType.Object, reflexive = true)
-//    val unexpectedRootTypes = rootTypes.filter(rt ⇒ (rt ne ObjectType.Object) && !isInterface(rt).isNo)
-//    unexpectedRootTypes.map(rt ⇒ allSubtypes(rt, reflexive = true)).flatten.view.
-//      filter(ot ⇒ !typesForWhichItMayBePossibleToComputeTheMutability.contains(ot)).
-//      foreach(ot ⇒ project.classFile(ot) foreach { cf ⇒
-//        classFileToObjectTypeCellCompleter(cf)._1.putFinal(Mutable)
-//      })
-//
-//    // 2. trigger analyses
-//    for {
-//      classFile <- project.allProjectClassFiles.par
-//    } {
-//      pool.execute(() => {
-//        if (!classFileToObjectTypeCellCompleter(classFile)._1.cell.isComplete)
-//          objectImmutabilityAnalysis(project, classFileToObjectTypeCellCompleter, manager, classFile)
-//      })
-//      pool.execute(() => {
-//        if (!classFileToObjectTypeCellCompleter(classFile)._2.cell.isComplete)
-//          typeImmutabilityAnalysis(project, classFileToObjectTypeCellCompleter, manager, classFile)
-//      })
-//    }
-//    pool.whileQuiescentResolveDefault
-//    pool.shutdown()
-//
-//    val endTime = System.currentTimeMillis
-//
-//    val setupTime = middleTime - startTime
-//    val analysisTime = endTime - middleTime
-//    val combinedTime = endTime - startTime
-//
-//    /* Fixes the results so the output looks good */
-//    val resultClassFiles = project.allProjectClassFiles.par.filter(!allInterfaces.contains(_))
-//    val mutableClassFilesInfo = for {
-//      cf <- resultClassFiles if (classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() == Mutable)
-//    } yield (cf.thisType.toJava + " => " +
-//      classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() + "Object => " +
-//      classFileToObjectTypeCellCompleter(cf)._2.cell.getResult() + "Type")
-//
-//    val immutableClassFilesInfo = for {
-//      cf <- resultClassFiles if (classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() == Immutable)
-//    } yield (cf.thisType.toJava + " => " +
-//      classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() + "Object => " +
-//      classFileToObjectTypeCellCompleter(cf)._2.cell.getResult() + "Type")
-//
-//    val conditionallyImmutableClassFilesInfo = for {
-//      cf <- resultClassFiles if (classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() == ConditionallyImmutable)
-//    } yield (cf.thisType.toJava + " => " +
-//      classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() + "Object => " +
-//      classFileToObjectTypeCellCompleter(cf)._2.cell.getResult() + "Type")
-//
-//    val sortedClassFilesInfo = (immutableClassFilesInfo.toList.sorted ++
-//      conditionallyImmutableClassFilesInfo.toList.sorted ++ mutableClassFilesInfo.toList.sorted)
-//    BasicReport(sortedClassFilesInfo.mkString("\n") +
-//      s"\nSETUP TIME: $setupTime" +
-//      s"\nANALYIS TIME: $analysisTime" +
-//      s"\nCOMBINED TIME: $combinedTime")
-//  }
-//
-//  /**
-//   * This function is used for the tests, to not run the external analyses several times.
-//   *
-//   * @param project
-//   * @param manager
-//   * @return
-//   */
-//  def analyzeWithoutClassExtensibilityAndFieldMutabilityAnalysis(
-//    project: Project[URL],
-//    manager: FPCFAnalysesManager): BasicReport = {
-//    // 1. Initialization of key data structures (two cell(completer) per class file)
-//    // One for Object Immutability and one for Type Immutability.
-//    val pool = new HandlerPool()
-//
-//    // classFileToObjectTypeCellCompleter._1 = ObjectImmutability
-//    // classFileToObjectTypeCellCompleter._2 = TypeImmutability
-//    var classFileToObjectTypeCellCompleter =
-//      Map.empty[ClassFile, (CellCompleter[ImmutabilityKey.type, Immutability], CellCompleter[ImmutabilityKey.type, Immutability])]
-//    for {
-//      classFile <- project.allProjectClassFiles
-//    } {
-//      val cellCompleter1 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
-//      val cellCompleter2 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
-//      classFileToObjectTypeCellCompleter = classFileToObjectTypeCellCompleter + ((classFile, (cellCompleter1, cellCompleter2)))
-//    }
-//
-//    // java.lang.Object is by definition immutable
-//    val objectClassFileOption = project.classFile(ObjectType.Object)
-//    objectClassFileOption.foreach { cf =>
-//      classFileToObjectTypeCellCompleter(cf)._1.putFinal(Immutable)
-//      classFileToObjectTypeCellCompleter(cf)._2.putFinal(Mutable) // Should the TypeImmutability be Mutable?
-//    }
-//
-//    // All interfaces are by definition immutable
-//    val allInterfaces = project.allProjectClassFiles.par.filter(cf => cf.isInterfaceDeclaration).toList
-//    allInterfaces.foreach(cf => classFileToObjectTypeCellCompleter(cf)._1.putFinal(Immutable))
-//
-//    val classHierarchy = project.classHierarchy
-//    import classHierarchy.allSubtypes
-//    import classHierarchy.rootTypes
-//    import classHierarchy.isInterface
-//    // All classes that do not have complete superclass information are mutable
-//    // due to the lack of knowledge.
-//    val typesForWhichItMayBePossibleToComputeTheMutability = allSubtypes(ObjectType.Object, reflexive = true)
-//    val unexpectedRootTypes = rootTypes.filter(rt ⇒ (rt ne ObjectType.Object) && !isInterface(rt).isNo)
-//    unexpectedRootTypes.map(rt ⇒ allSubtypes(rt, reflexive = true)).flatten.view.
-//      filter(ot ⇒ !typesForWhichItMayBePossibleToComputeTheMutability.contains(ot)).
-//      foreach(ot ⇒ project.classFile(ot) foreach { cf ⇒
-//        classFileToObjectTypeCellCompleter(cf)._1.putFinal(Mutable)
-//      })
-//
-//    // 2. trigger analyses
-//    for {
-//      classFile <- project.allProjectClassFiles.par
-//    } {
-//      pool.execute(() => {
-//        if (!classFileToObjectTypeCellCompleter(classFile)._1.cell.isComplete)
-//          objectImmutabilityAnalysis(project, classFileToObjectTypeCellCompleter, manager, classFile)
-//      })
-//      pool.execute(() => {
-//        if (!classFileToObjectTypeCellCompleter(classFile)._2.cell.isComplete)
-//          typeImmutabilityAnalysis(project, classFileToObjectTypeCellCompleter, manager, classFile)
-//      })
-//    }
-//    pool.whileQuiescentResolveCell
-//    pool.shutdown()
-//
-//    /* Fixes the results so the output looks good */
-//    val mutableClassFilesInfo = for {
-//      (cf, (objImmutability, typeImmutability)) <- classFileToObjectTypeCellCompleter if (objImmutability.cell.getResult() == Mutable)
-//    } yield (cf.thisType.toJava + " => " + objImmutability.cell.getResult() + "Object => " + typeImmutability.cell.getResult() + "Type")
-//
-//    val immutableClassFilesInfo = for {
-//      (cf, (objImmutability, typeImmutability)) <- classFileToObjectTypeCellCompleter if (objImmutability.cell.getResult() == Immutable)
-//    } yield (cf.thisType.toJava + " => " + objImmutability.cell.getResult() + "Object => " + typeImmutability.cell.getResult() + "Type")
-//
-//    val conditionallyImmutableClassFilesInfo = for {
-//      (cf, (objImmutability, typeImmutability)) <- classFileToObjectTypeCellCompleter if (objImmutability.cell.getResult() == ConditionallyImmutable)
-//    } yield (cf.thisType.toJava + " => " + objImmutability.cell.getResult() + "Object => " + typeImmutability.cell.getResult() + "Type")
-//
-//    val sortedClassFilesInfo = (immutableClassFilesInfo.toList.sorted ++
-//      conditionallyImmutableClassFilesInfo.toList.sorted ++ mutableClassFilesInfo.toList.sorted)
-//    BasicReport(sortedClassFilesInfo)
-//  }
-//
-//  /**
-//   *  Determines a class files' ObjectImmutability.
-//   */
-//  def objectImmutabilityAnalysis(
-//    project: Project[URL],
-//    classFileToObjectTypeCellCompleter: Map[ClassFile, (CellCompleter[ImmutabilityKey.type, Immutability], CellCompleter[ImmutabilityKey.type, Immutability])],
-//    manager: FPCFAnalysesManager,
-//    cf: ClassFile): Unit = {
-//    val cellCompleter = classFileToObjectTypeCellCompleter(cf)._1
-//
-//    val classHierarchy = project.classHierarchy
-//    val directSuperTypes = classHierarchy.directSupertypes(cf.thisType)
-//
-//    // Check fields to determine ObjectImmutability
-//    val nonFinalInstanceFields = cf.fields.collect { case f if !f.isStatic && !f.isFinal => f }
-//
-//    if (!nonFinalInstanceFields.isEmpty)
-//      cellCompleter.putFinal(Mutable)
-//
-//    // If the cell hasn't already been completed with an ObjectImmutability, then it is
-//    // dependent on FieldMutability and its superclasses
-//    if (!cellCompleter.cell.isComplete) {
-//      if (cf.fields.exists(f => !f.isStatic && f.fieldType.isArrayType))
-//        cellCompleter.putNext(ConditionallyImmutable)
-//      else {
-//        val fieldTypes: Set[ObjectType] =
-//          cf.fields.collect {
-//            case f if !f.isStatic && f.fieldType.isObjectType => f.fieldType.asObjectType
-//          }.toSet
-//
-//        val hasUnresolvableDependencies =
-//          fieldTypes.exists { t =>
-//            project.classFile(t) match {
-//              case None => true /* we have an unresolved dependency */
-//              case Some(classFile) => false /* do nothing */
-//            }
-//          }
-//
-//        if (hasUnresolvableDependencies)
-//          cellCompleter.putNext(ConditionallyImmutable)
-//        else {
-//          val finalInstanceFields = cf.fields.collect { case f if !f.isStatic && f.isFinal => f }
-//          finalInstanceFields.foreach { f =>
-//            if (f.fieldType.isObjectType) {
-//              project.classFile(f.fieldType.asObjectType) match {
-//                case Some(classFile) =>
-//                  val fieldTypeCell = classFileToObjectTypeCellCompleter(classFile)._2.cell
-//                  cellCompleter.cell.whenNext(
-//                    fieldTypeCell,
-//                    (fieldImm: Immutability, _) => fieldImm match {
-//                      case Mutable | ConditionallyImmutable => NextOutcome(ConditionallyImmutable)
-//                      case Immutable => NoOutcome
-//                    })
-//                case None => /* Do nothing */
-//              }
-//            }
-//          }
-//        }
-//      }
-//      // Check with superclass to determine ObjectImmutability
-//      val directSuperClasses = directSuperTypes.
-//        filter(superType => project.classFile(superType) != None).
-//        map(superType => project.classFile(superType).get)
-//
-//      directSuperClasses foreach { superClass =>
-//        cellCompleter.cell.whenNext(
-//          classFileToObjectTypeCellCompleter(superClass)._1.cell,
-//          (imm: Immutability, _) => imm match {
-//            case Immutable => NoOutcome
-//            case Mutable => FinalOutcome(imm)
-//            case ConditionallyImmutable => NextOutcome(imm)
-//          })
-//      }
-//    }
-//  }
-//
-//  /**
-//   *  Determines a class files' TypeImmutability.
-//   */
-//  def typeImmutabilityAnalysis(
-//    project: Project[URL],
-//    classFileToObjectTypeCellCompleter: Map[ClassFile, (CellCompleter[ImmutabilityKey.type, Immutability], CellCompleter[ImmutabilityKey.type, Immutability])],
-//    manager: FPCFAnalysesManager,
-//    cf: ClassFile): Unit = {
-//    val typeExtensibility = project.get(TypeExtensibilityKey)
-//    val cellCompleter = classFileToObjectTypeCellCompleter(cf)._2
-//    val isExtensible = typeExtensibility(cf.thisType)
-//    if (isExtensible.isYesOrUnknown)
-//      cellCompleter.putFinal(Mutable)
-//
-//    val classHierarchy = project.classHierarchy
-//    val directSubtypes = classHierarchy.directSubtypesOf(cf.thisType)
-//
-//    if (!cellCompleter.cell.isComplete) {
-//      // If this class file doesn't have subtypes, then the TypeImmutability is the same as
-//      // the ObjectImmutability
-//      if (cf.isFinal || directSubtypes.isEmpty) {
-//        cellCompleter.cell.whenNext(
-//          classFileToObjectTypeCellCompleter(cf)._1.cell,
-//          (imm: Immutability) => imm match {
-//            case Immutable => FalsePred
-//            case Mutable => WhenNextComplete
-//            case ConditionallyImmutable => WhenNext
-//          },
-//          Some(_))
-//      } else {
-//        val unavailableSubtype = directSubtypes.find(t ⇒ project.classFile(t).isEmpty)
-//        if (unavailableSubtype.isDefined)
-//          cellCompleter.putFinal(Mutable)
-//
-//        if (!cellCompleter.cell.isComplete) {
-//          // Check subclasses to determine TypeImmutability
-//          val directSubclasses = directSubtypes map { subtype ⇒ project.classFile(subtype).get }
-//          directSubclasses foreach { subclass =>
-//            cellCompleter.cell.whenNext(
-//              classFileToObjectTypeCellCompleter(subclass)._2.cell,
-//              (imm: Immutability) => imm match {
-//                case Immutable => FalsePred
-//                case Mutable => WhenNextComplete
-//                case ConditionallyImmutable => WhenNext
-//              },
-//              Some(_))
-//          }
-//        }
-//      }
-//    }
-//  }
-//}
+package opal
+
+import java.net.URL
+
+import org.opalj.fpcf._
+
+import scala.collection.JavaConverters._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import cell._
+import org.opalj.br.{ Field, ClassFile, ObjectType }
+import org.opalj.br.analyses.{ BasicReport, DefaultOneStepAnalysis, Project, PropertyStoreKey }
+import org.opalj.br.analyses.TypeExtensibilityKey
+import org.opalj.fpcf.analyses.FieldMutabilityAnalysis
+import org.opalj.fpcf.properties.FieldMutability
+
+object ImmutabilityAnalysis extends DefaultOneStepAnalysis {
+
+  override def doAnalyze(
+    project: Project[URL],
+    parameters: Seq[String] = List.empty,
+    isInterrupted: () ⇒ Boolean): BasicReport = {
+    // Run ClassExtensibilityAnalysis
+    val projectStore = project.get(PropertyStoreKey)
+    val manager = project.get(FPCFAnalysesManagerKey)
+    //manager.runAll(
+    //FieldMutabilityAnalysis
+    // REPLACED                ObjectImmutabilityAnalysis
+    // REPLACED                TypeImmutabilityAnalysis
+    //)
+
+    val startTime = System.currentTimeMillis // Used for measuring execution time
+
+    // 1. Initialization of key data structures (two cell(completer) per class file)
+    // One for Object Immutability and one for Type Immutability.
+    val pool = new HandlerPool()
+
+    // classFileToObjectTypeCellCompleter._1 = ObjectImmutability
+    // classFileToObjectTypeCellCompleter._2 = TypeImmutability
+    var classFileToObjectTypeCellCompleter =
+      Map.empty[ClassFile, (CellCompleter[ImmutabilityKey.type, Immutability], CellCompleter[ImmutabilityKey.type, Immutability])]
+    for {
+      classFile <- project.allProjectClassFiles
+    } {
+      val cellCompleter1 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
+      val cellCompleter2 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
+      classFileToObjectTypeCellCompleter = classFileToObjectTypeCellCompleter + ((classFile, (cellCompleter1, cellCompleter2)))
+    }
+
+    val middleTime = System.currentTimeMillis
+
+    // java.lang.Object is by definition immutable
+    val objectClassFileOption = project.classFile(ObjectType.Object)
+    objectClassFileOption.foreach { cf =>
+      classFileToObjectTypeCellCompleter(cf)._1.putFinal(Immutable)
+      classFileToObjectTypeCellCompleter(cf)._2.putFinal(Mutable)
+    }
+
+    // All interfaces are by definition immutable
+    val allInterfaces = project.allProjectClassFiles.par.filter(cf => cf.isInterfaceDeclaration).toList
+    allInterfaces.foreach(cf => classFileToObjectTypeCellCompleter(cf)._1.putFinal(Immutable))
+
+    val classHierarchy = project.classHierarchy
+    import classHierarchy.allSubtypes
+    import classHierarchy.rootTypes
+    import classHierarchy.isInterface
+    // All classes that do not have complete superclass information are mutable
+    // due to the lack of knowledge.
+    val typesForWhichItMayBePossibleToComputeTheMutability = allSubtypes(ObjectType.Object, reflexive = true)
+    val unexpectedRootTypes = rootTypes.filter(rt ⇒ (rt ne ObjectType.Object) && !isInterface(rt).isNo)
+    unexpectedRootTypes.map(rt ⇒ allSubtypes(rt, reflexive = true)).flatten.view.
+      filter(ot ⇒ !typesForWhichItMayBePossibleToComputeTheMutability.contains(ot)).
+      foreach(ot ⇒ project.classFile(ot) foreach { cf ⇒
+        classFileToObjectTypeCellCompleter(cf)._1.putFinal(Mutable)
+      })
+
+    // 2. trigger analyses
+    for {
+      classFile <- project.allProjectClassFiles.par
+    } {
+      pool.execute(() => {
+        if (!classFileToObjectTypeCellCompleter(classFile)._1.cell.isComplete)
+          objectImmutabilityAnalysis(project, classFileToObjectTypeCellCompleter, manager, classFile)
+      })
+      pool.execute(() => {
+        if (!classFileToObjectTypeCellCompleter(classFile)._2.cell.isComplete)
+          typeImmutabilityAnalysis(project, classFileToObjectTypeCellCompleter, manager, classFile)
+      })
+    }
+    pool.whileQuiescentResolveDefault
+    pool.shutdown()
+
+    val endTime = System.currentTimeMillis
+
+    val setupTime = middleTime - startTime
+    val analysisTime = endTime - middleTime
+    val combinedTime = endTime - startTime
+
+    /* Fixes the results so the output looks good */
+    val resultClassFiles = project.allProjectClassFiles.par.filter(!allInterfaces.contains(_))
+    val mutableClassFilesInfo = for {
+      cf <- resultClassFiles if (classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() == Mutable)
+    } yield (cf.thisType.toJava + " => " +
+      classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() + "Object => " +
+      classFileToObjectTypeCellCompleter(cf)._2.cell.getResult() + "Type")
+
+    val immutableClassFilesInfo = for {
+      cf <- resultClassFiles if (classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() == Immutable)
+    } yield (cf.thisType.toJava + " => " +
+      classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() + "Object => " +
+      classFileToObjectTypeCellCompleter(cf)._2.cell.getResult() + "Type")
+
+    val conditionallyImmutableClassFilesInfo = for {
+      cf <- resultClassFiles if (classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() == ConditionallyImmutable)
+    } yield (cf.thisType.toJava + " => " +
+      classFileToObjectTypeCellCompleter(cf)._1.cell.getResult() + "Object => " +
+      classFileToObjectTypeCellCompleter(cf)._2.cell.getResult() + "Type")
+
+    val sortedClassFilesInfo = (immutableClassFilesInfo.toList.sorted ++
+      conditionallyImmutableClassFilesInfo.toList.sorted ++ mutableClassFilesInfo.toList.sorted)
+    BasicReport(sortedClassFilesInfo.mkString("\n") +
+      s"\nSETUP TIME: $setupTime" +
+      s"\nANALYIS TIME: $analysisTime" +
+      s"\nCOMBINED TIME: $combinedTime")
+  }
+
+  /**
+   * This function is used for the tests, to not run the external analyses several times.
+   *
+   * @param project
+   * @param manager
+   * @return
+   */
+  def analyzeWithoutClassExtensibilityAndFieldMutabilityAnalysis(
+    project: Project[URL],
+    manager: FPCFAnalysesManager): BasicReport = {
+    // 1. Initialization of key data structures (two cell(completer) per class file)
+    // One for Object Immutability and one for Type Immutability.
+    val pool = new HandlerPool()
+
+    // classFileToObjectTypeCellCompleter._1 = ObjectImmutability
+    // classFileToObjectTypeCellCompleter._2 = TypeImmutability
+    var classFileToObjectTypeCellCompleter =
+      Map.empty[ClassFile, (CellCompleter[ImmutabilityKey.type, Immutability], CellCompleter[ImmutabilityKey.type, Immutability])]
+    for {
+      classFile <- project.allProjectClassFiles
+    } {
+      val cellCompleter1 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
+      val cellCompleter2 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
+      classFileToObjectTypeCellCompleter = classFileToObjectTypeCellCompleter + ((classFile, (cellCompleter1, cellCompleter2)))
+    }
+
+    // java.lang.Object is by definition immutable
+    val objectClassFileOption = project.classFile(ObjectType.Object)
+    objectClassFileOption.foreach { cf =>
+      classFileToObjectTypeCellCompleter(cf)._1.putFinal(Immutable)
+      classFileToObjectTypeCellCompleter(cf)._2.putFinal(Mutable) // Should the TypeImmutability be Mutable?
+    }
+
+    // All interfaces are by definition immutable
+    val allInterfaces = project.allProjectClassFiles.par.filter(cf => cf.isInterfaceDeclaration).toList
+    allInterfaces.foreach(cf => classFileToObjectTypeCellCompleter(cf)._1.putFinal(Immutable))
+
+    val classHierarchy = project.classHierarchy
+    import classHierarchy.allSubtypes
+    import classHierarchy.rootTypes
+    import classHierarchy.isInterface
+    // All classes that do not have complete superclass information are mutable
+    // due to the lack of knowledge.
+    val typesForWhichItMayBePossibleToComputeTheMutability = allSubtypes(ObjectType.Object, reflexive = true)
+    val unexpectedRootTypes = rootTypes.filter(rt ⇒ (rt ne ObjectType.Object) && !isInterface(rt).isNo)
+    unexpectedRootTypes.map(rt ⇒ allSubtypes(rt, reflexive = true)).flatten.view.
+      filter(ot ⇒ !typesForWhichItMayBePossibleToComputeTheMutability.contains(ot)).
+      foreach(ot ⇒ project.classFile(ot) foreach { cf ⇒
+        classFileToObjectTypeCellCompleter(cf)._1.putFinal(Mutable)
+      })
+
+    // 2. trigger analyses
+    for {
+      classFile <- project.allProjectClassFiles.par
+    } {
+      pool.execute(() => {
+        if (!classFileToObjectTypeCellCompleter(classFile)._1.cell.isComplete)
+          objectImmutabilityAnalysis(project, classFileToObjectTypeCellCompleter, manager, classFile)
+      })
+      pool.execute(() => {
+        if (!classFileToObjectTypeCellCompleter(classFile)._2.cell.isComplete)
+          typeImmutabilityAnalysis(project, classFileToObjectTypeCellCompleter, manager, classFile)
+      })
+    }
+    pool.whileQuiescentResolveCell
+    pool.shutdown()
+
+    /* Fixes the results so the output looks good */
+    val mutableClassFilesInfo = for {
+      (cf, (objImmutability, typeImmutability)) <- classFileToObjectTypeCellCompleter if (objImmutability.cell.getResult() == Mutable)
+    } yield (cf.thisType.toJava + " => " + objImmutability.cell.getResult() + "Object => " + typeImmutability.cell.getResult() + "Type")
+
+    val immutableClassFilesInfo = for {
+      (cf, (objImmutability, typeImmutability)) <- classFileToObjectTypeCellCompleter if (objImmutability.cell.getResult() == Immutable)
+    } yield (cf.thisType.toJava + " => " + objImmutability.cell.getResult() + "Object => " + typeImmutability.cell.getResult() + "Type")
+
+    val conditionallyImmutableClassFilesInfo = for {
+      (cf, (objImmutability, typeImmutability)) <- classFileToObjectTypeCellCompleter if (objImmutability.cell.getResult() == ConditionallyImmutable)
+    } yield (cf.thisType.toJava + " => " + objImmutability.cell.getResult() + "Object => " + typeImmutability.cell.getResult() + "Type")
+
+    val sortedClassFilesInfo = (immutableClassFilesInfo.toList.sorted ++
+      conditionallyImmutableClassFilesInfo.toList.sorted ++ mutableClassFilesInfo.toList.sorted)
+    BasicReport(sortedClassFilesInfo)
+  }
+
+  /**
+   *  Determines a class files' ObjectImmutability.
+   */
+  def objectImmutabilityAnalysis(
+    project: Project[URL],
+    classFileToObjectTypeCellCompleter: Map[ClassFile, (CellCompleter[ImmutabilityKey.type, Immutability], CellCompleter[ImmutabilityKey.type, Immutability])],
+    manager: FPCFAnalysesManager,
+    cf: ClassFile): Unit = {
+    val cellCompleter = classFileToObjectTypeCellCompleter(cf)._1
+
+    val classHierarchy = project.classHierarchy
+    val directSuperTypes = classHierarchy.directSupertypes(cf.thisType)
+
+    // Check fields to determine ObjectImmutability
+    val nonFinalInstanceFields = cf.fields.collect { case f if !f.isStatic && !f.isFinal => f }
+
+    if (!nonFinalInstanceFields.isEmpty)
+      cellCompleter.putFinal(Mutable)
+
+    // If the cell hasn't already been completed with an ObjectImmutability, then it is
+    // dependent on FieldMutability and its superclasses
+    if (!cellCompleter.cell.isComplete) {
+      if (cf.fields.exists(f => !f.isStatic && f.fieldType.isArrayType))
+        cellCompleter.putNext(ConditionallyImmutable)
+      else {
+        val fieldTypes: Set[ObjectType] =
+          cf.fields.collect {
+            case f if !f.isStatic && f.fieldType.isObjectType => f.fieldType.asObjectType
+          }.toSet
+
+        val hasUnresolvableDependencies =
+          fieldTypes.exists { t =>
+            project.classFile(t) match {
+              case None => true /* we have an unresolved dependency */
+              case Some(classFile) => false /* do nothing */
+            }
+          }
+
+        if (hasUnresolvableDependencies)
+          cellCompleter.putNext(ConditionallyImmutable)
+        else {
+          val finalInstanceFields = cf.fields.collect { case f if !f.isStatic && f.isFinal => f }
+          finalInstanceFields.foreach { f =>
+            if (f.fieldType.isObjectType) {
+              project.classFile(f.fieldType.asObjectType) match {
+                case Some(classFile) =>
+                  val fieldTypeCell = classFileToObjectTypeCellCompleter(classFile)._2.cell
+                  cellCompleter.cell.whenNext(
+                    fieldTypeCell,
+                    (fieldImm: Immutability, _) => fieldImm match {
+                      case Mutable | ConditionallyImmutable => NextOutcome(ConditionallyImmutable)
+                      case Immutable => NoOutcome
+                    })
+                case None => /* Do nothing */
+              }
+            }
+          }
+        }
+      }
+      // Check with superclass to determine ObjectImmutability
+      val directSuperClasses = directSuperTypes.
+        filter(superType => project.classFile(superType) != None).
+        map(superType => project.classFile(superType).get)
+
+      directSuperClasses foreach { superClass =>
+        cellCompleter.cell.whenNext(
+          classFileToObjectTypeCellCompleter(superClass)._1.cell,
+          (imm: Immutability, _) => imm match {
+            case Immutable => NoOutcome
+            case Mutable => FinalOutcome(imm)
+            case ConditionallyImmutable => NextOutcome(imm)
+          })
+      }
+    }
+  }
+
+  /**
+   *  Determines a class files' TypeImmutability.
+   */
+  def typeImmutabilityAnalysis(
+    project: Project[URL],
+    classFileToObjectTypeCellCompleter: Map[ClassFile, (CellCompleter[ImmutabilityKey.type, Immutability], CellCompleter[ImmutabilityKey.type, Immutability])],
+    manager: FPCFAnalysesManager,
+    cf: ClassFile): Unit = {
+    val typeExtensibility = project.get(TypeExtensibilityKey)
+    val cellCompleter = classFileToObjectTypeCellCompleter(cf)._2
+    val isExtensible = typeExtensibility(cf.thisType)
+    if (isExtensible.isYesOrUnknown)
+      cellCompleter.putFinal(Mutable)
+
+    val classHierarchy = project.classHierarchy
+    val directSubtypes = classHierarchy.directSubtypesOf(cf.thisType)
+
+    if (!cellCompleter.cell.isComplete) {
+      // If this class file doesn't have subtypes, then the TypeImmutability is the same as
+      // the ObjectImmutability
+      if (cf.isFinal || directSubtypes.isEmpty) {
+        cellCompleter.cell.whenNext(
+          classFileToObjectTypeCellCompleter(cf)._1.cell,
+          (imm: Immutability, _) => imm match {
+            case Immutable => NoOutcome
+            case Mutable => FinalOutcome(imm)
+            case ConditionallyImmutable => NextOutcome(imm)
+          })
+      } else {
+        val unavailableSubtype = directSubtypes.find(t ⇒ project.classFile(t).isEmpty)
+        if (unavailableSubtype.isDefined)
+          cellCompleter.putFinal(Mutable)
+
+        if (!cellCompleter.cell.isComplete) {
+          // Check subclasses to determine TypeImmutability
+          val directSubclasses = directSubtypes map { subtype ⇒ project.classFile(subtype).get }
+          directSubclasses foreach { subclass =>
+            cellCompleter.cell.whenNext(
+              classFileToObjectTypeCellCompleter(subclass)._2.cell,
+              (imm: Immutability, _) => imm match {
+                case Immutable => NoOutcome
+                case Mutable => FinalOutcome(imm)
+                case ConditionallyImmutable => NextOutcome(imm)
+              })
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/main/scala/opal/PurityAnalysis.scala
+++ b/core/src/main/scala/opal/PurityAnalysis.scala
@@ -1,205 +1,207 @@
-//package opal
-//
-//import java.net.URL
-//
-//import scala.collection.JavaConverters._
-//import scala.concurrent.Await
-//import scala.concurrent.duration._
-//import cell._
-//import org.opalj.Success
-//import org.opalj.br.{ ClassFile, Method, MethodWithBody, PC }
-//import org.opalj.br.analyses.{ BasicReport, DefaultOneStepAnalysis, Project }
-//import org.opalj.br.instructions.GETFIELD
-//import org.opalj.br.instructions.GETSTATIC
-//import org.opalj.br.instructions.PUTFIELD
-//import org.opalj.br.instructions.PUTSTATIC
-//import org.opalj.br.instructions.MONITORENTER
-//import org.opalj.br.instructions.MONITOREXIT
-//import org.opalj.br.instructions.NEW
-//import org.opalj.br.instructions.NEWARRAY
-//import org.opalj.br.instructions.MULTIANEWARRAY
-//import org.opalj.br.instructions.ANEWARRAY
-//import org.opalj.br.instructions.AALOAD
-//import org.opalj.br.instructions.AASTORE
-//import org.opalj.br.instructions.ARRAYLENGTH
-//import org.opalj.br.instructions.LALOAD
-//import org.opalj.br.instructions.IALOAD
-//import org.opalj.br.instructions.CALOAD
-//import org.opalj.br.instructions.BALOAD
-//import org.opalj.br.instructions.BASTORE
-//import org.opalj.br.instructions.CASTORE
-//import org.opalj.br.instructions.IASTORE
-//import org.opalj.br.instructions.LASTORE
-//import org.opalj.br.instructions.SASTORE
-//import org.opalj.br.instructions.SALOAD
-//import org.opalj.br.instructions.DALOAD
-//import org.opalj.br.instructions.FALOAD
-//import org.opalj.br.instructions.FASTORE
-//import org.opalj.br.instructions.DASTORE
-//import org.opalj.br.instructions.INVOKEDYNAMIC
-//import org.opalj.br.instructions.INVOKESTATIC
-//import org.opalj.br.instructions.INVOKESPECIAL
-//import org.opalj.br.instructions.INVOKEVIRTUAL
-//import org.opalj.br.instructions.INVOKEINTERFACE
-//import org.opalj.br.instructions.MethodInvocationInstruction
-//import org.opalj.br.instructions.NonVirtualMethodInvocationInstruction
-//
-//object PurityAnalysis extends DefaultOneStepAnalysis {
-//
-//  override def doAnalyze(
-//    project: Project[URL],
-//    parameters: Seq[String] = List.empty,
-//    isInterrupted: () ⇒ Boolean): BasicReport = {
-//
-//    val startTime = System.currentTimeMillis // Used for measuring execution time
-//    // 1. Initialization of key data structures (one cell(completer) per method)
-//    val pool = new HandlerPool()
-//    var methodToCellCompleter = Map.empty[Method, CellCompleter[PurityKey.type, Purity]]
-//    for {
-//      classFile <- project.allProjectClassFiles
-//      method <- classFile.methods
-//    } {
-//      val cellCompleter = CellCompleter[PurityKey.type, Purity](pool, PurityKey)
-//      methodToCellCompleter = methodToCellCompleter + ((method, cellCompleter))
-//    }
-//
-//    val middleTime = System.currentTimeMillis
-//
-//    // 2. trigger analyses
-//    for {
-//      classFile <- project.allProjectClassFiles.par
-//      method <- classFile.methods
-//    } {
-//      pool.execute(() => analyze(project, methodToCellCompleter, classFile, method))
-//    }
-//    val fut = pool.quiescentResolveCell
-//    Await.ready(fut, 30.minutes)
-//    pool.shutdown()
-//
-//    val endTime = System.currentTimeMillis
-//
-//    val setupTime = middleTime - startTime
-//    val analysisTime = endTime - middleTime
-//    val combinedTime = endTime - startTime
-//
-//    val pureMethods = methodToCellCompleter.filter(_._2.cell.getResult match {
-//      case Pure => true
-//      case _ => false
-//    }).map(_._1)
-//
-//    val pureMethodsInfo = pureMethods.map(m => m.toJava("")).toList.sorted
-//
-//    BasicReport("pure methods analysis:\n" + pureMethodsInfo.mkString("\n") +
-//      s"\nSETUP TIME: $setupTime" +
-//      s"\nANALYIS TIME: $analysisTime" +
-//      s"\nCOMBINED TIME: $combinedTime")
-//  }
-//
-//  /**
-//   * Determines the purity of the given method.
-//   */
-//  def analyze(
-//    project: Project[URL],
-//    methodToCellCompleter: Map[Method, CellCompleter[PurityKey.type, Purity]],
-//    classFile: ClassFile,
-//    method: Method): Unit = {
-//
-//    val cellCompleter = methodToCellCompleter(method)
-//
-//    if ( // Due to a lack of knowledge, we classify all native methods or methods that
-//    // belong to a library (and hence lack the body) as impure...
-//    method.body.isEmpty /*HERE: method.isNative || "isLibraryMethod(method)"*/ ||
-//      // for simplicity we are just focusing on methods that do not take objects as parameters
-//      method.parameterTypes.exists(!_.isBaseType)) {
-//      cellCompleter.putFinal(Impure)
-//      return ;
-//    }
-//
-//    var hasDependencies = false
-//    val declaringClassType = classFile.thisType
-//    val methodDescriptor = method.descriptor
-//    val methodName = method.name
-//    val body = method.body.get
-//    val instructions = body.instructions
-//    val maxPC = instructions.size
-//
-//    var currentPC = 0
-//    while (currentPC < maxPC) {
-//      val instruction = instructions(currentPC)
-//
-//      (instruction.opcode: @scala.annotation.switch) match {
-//        case GETSTATIC.opcode ⇒
-//          val GETSTATIC(declaringClass, fieldName, fieldType) = instruction
-//          import project.resolveFieldReference
-//          resolveFieldReference(declaringClass, fieldName, fieldType) match {
-//
-//            case Some(field) if field.isFinal ⇒
-//            /* Nothing to do; constants do not impede purity! */
-//
-//            // case Some(field) if field.isPrivate /*&& field.isNonFinal*/ ⇒
-//            // check if the field is effectively final
-//
-//            case _ ⇒
-//              cellCompleter.putFinal(Impure)
-//              return ;
-//          }
-//
-//        case INVOKESPECIAL.opcode | INVOKESTATIC.opcode ⇒ instruction match {
-//
-//          case MethodInvocationInstruction(`declaringClassType`, _, `methodName`, `methodDescriptor`) ⇒
-//          // We have a self-recursive call; such calls do not influence
-//          // the computation of the method's purity and are ignored.
-//          // Let's continue with the evaluation of the next instruction.
-//
-//          case mii: NonVirtualMethodInvocationInstruction ⇒
-//
-//          //            nonVirtualCall(mii) match {
-//          //
-//          //              case Success(callee) ⇒
-//          //                /* Recall that self-recursive calls are handled earlier! */
-//          //                val targetCellCompleter = methodToCellCompleter(callee)
-//          //                hasDependencies = true
-//          //                cellCompleter.cell.whenNext(targetCellCompleter.cell, (p: Purity) => if(p == Impure)  WhenNextComplete else FalsePred, (_, isFinal) => if(isFinal) Some(Impure) else None)
-//          //
-//          //
-//          //              case _ /* Empty or Failure */ ⇒
-//          //
-//          //                // We know nothing about the target method (it is not
-//          //                // found in the scope of the current project).
-//          //                cellCompleter.putFinal(Impure)
-//          //                return ;
-//          //            }
-//
-//        }
-//
-//        case NEW.opcode |
-//          GETFIELD.opcode |
-//          PUTFIELD.opcode | PUTSTATIC.opcode |
-//          NEWARRAY.opcode | MULTIANEWARRAY.opcode | ANEWARRAY.opcode |
-//          AALOAD.opcode | AASTORE.opcode |
-//          BALOAD.opcode | BASTORE.opcode |
-//          CALOAD.opcode | CASTORE.opcode |
-//          SALOAD.opcode | SASTORE.opcode |
-//          IALOAD.opcode | IASTORE.opcode |
-//          LALOAD.opcode | LASTORE.opcode |
-//          DALOAD.opcode | DASTORE.opcode |
-//          FALOAD.opcode | FASTORE.opcode |
-//          ARRAYLENGTH.opcode |
-//          MONITORENTER.opcode | MONITOREXIT.opcode |
-//          INVOKEDYNAMIC.opcode | INVOKEVIRTUAL.opcode | INVOKEINTERFACE.opcode ⇒
-//          cellCompleter.putFinal(Impure)
-//          return ;
-//
-//        case _ ⇒
-//        /* All other instructions (IFs, Load/Stores, Arith., etc.) are pure. */
-//      }
-//      currentPC = body.pcOfNextInstruction(currentPC)
-//    }
-//
-//    // Every method that is not identified as being impure is (conditionally)pure.
-//    if (!hasDependencies) {
-//      cellCompleter.putFinal(Pure)
-//      //println("Immediately Pure Method: "+method.toJava(classFile))
-//    }
-//  }
-//}
+package opal
+
+import java.net.URL
+
+import scala.collection.JavaConverters._
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import cell._
+import org.opalj.Success
+import org.opalj.br.{ ClassFile, Method, MethodWithBody, PC }
+import org.opalj.br.analyses.{ BasicReport, DefaultOneStepAnalysis, Project }
+import org.opalj.br.instructions.GETFIELD
+import org.opalj.br.instructions.GETSTATIC
+import org.opalj.br.instructions.PUTFIELD
+import org.opalj.br.instructions.PUTSTATIC
+import org.opalj.br.instructions.MONITORENTER
+import org.opalj.br.instructions.MONITOREXIT
+import org.opalj.br.instructions.NEW
+import org.opalj.br.instructions.NEWARRAY
+import org.opalj.br.instructions.MULTIANEWARRAY
+import org.opalj.br.instructions.ANEWARRAY
+import org.opalj.br.instructions.AALOAD
+import org.opalj.br.instructions.AASTORE
+import org.opalj.br.instructions.ARRAYLENGTH
+import org.opalj.br.instructions.LALOAD
+import org.opalj.br.instructions.IALOAD
+import org.opalj.br.instructions.CALOAD
+import org.opalj.br.instructions.BALOAD
+import org.opalj.br.instructions.BASTORE
+import org.opalj.br.instructions.CASTORE
+import org.opalj.br.instructions.IASTORE
+import org.opalj.br.instructions.LASTORE
+import org.opalj.br.instructions.SASTORE
+import org.opalj.br.instructions.SALOAD
+import org.opalj.br.instructions.DALOAD
+import org.opalj.br.instructions.FALOAD
+import org.opalj.br.instructions.FASTORE
+import org.opalj.br.instructions.DASTORE
+import org.opalj.br.instructions.INVOKEDYNAMIC
+import org.opalj.br.instructions.INVOKESTATIC
+import org.opalj.br.instructions.INVOKESPECIAL
+import org.opalj.br.instructions.INVOKEVIRTUAL
+import org.opalj.br.instructions.INVOKEINTERFACE
+import org.opalj.br.instructions.MethodInvocationInstruction
+import org.opalj.br.instructions.NonVirtualMethodInvocationInstruction
+
+object PurityAnalysis extends DefaultOneStepAnalysis {
+
+  override def doAnalyze(
+    project: Project[URL],
+    parameters: Seq[String] = List.empty,
+    isInterrupted: () ⇒ Boolean): BasicReport = {
+
+    val startTime = System.currentTimeMillis // Used for measuring execution time
+    // 1. Initialization of key data structures (one cell(completer) per method)
+    val pool = new HandlerPool()
+    var methodToCellCompleter = Map.empty[Method, CellCompleter[PurityKey.type, Purity]]
+    for {
+      classFile <- project.allProjectClassFiles
+      method <- classFile.methods
+    } {
+      val cellCompleter = CellCompleter[PurityKey.type, Purity](pool, PurityKey)
+      methodToCellCompleter = methodToCellCompleter + ((method, cellCompleter))
+    }
+
+    val middleTime = System.currentTimeMillis
+
+    // 2. trigger analyses
+    for {
+      classFile <- project.allProjectClassFiles.par
+      method <- classFile.methods
+    } {
+      pool.execute(() => analyze(project, methodToCellCompleter, classFile, method))
+    }
+    val fut = pool.quiescentResolveCell
+    Await.ready(fut, 30.minutes)
+    pool.shutdown()
+
+    val endTime = System.currentTimeMillis
+
+    val setupTime = middleTime - startTime
+    val analysisTime = endTime - middleTime
+    val combinedTime = endTime - startTime
+
+    val pureMethods = methodToCellCompleter.filter(_._2.cell.getResult match {
+      case Pure => true
+      case _ => false
+    }).map(_._1)
+
+    val pureMethodsInfo = pureMethods.map(m => m.toJava).toList.sorted
+
+    BasicReport("pure methods analysis:\n" + pureMethodsInfo.mkString("\n") +
+      s"\nSETUP TIME: $setupTime" +
+      s"\nANALYIS TIME: $analysisTime" +
+      s"\nCOMBINED TIME: $combinedTime")
+  }
+
+  /**
+   * Determines the purity of the given method.
+   */
+  def analyze(
+    project: Project[URL],
+    methodToCellCompleter: Map[Method, CellCompleter[PurityKey.type, Purity]],
+    classFile: ClassFile,
+    method: Method): Unit = {
+
+    import project.nonVirtualCall
+
+    val cellCompleter = methodToCellCompleter(method)
+
+    if ( // Due to a lack of knowledge, we classify all native methods or methods that
+    // belong to a library (and hence lack the body) as impure...
+    method.body.isEmpty /*HERE: method.isNative || "isLibraryMethod(method)"*/ ||
+      // for simplicity we are just focusing on methods that do not take objects as parameters
+      method.parameterTypes.exists(!_.isBaseType)) {
+      cellCompleter.putFinal(Impure)
+      return ;
+    }
+
+    var hasDependencies = false
+    val declaringClassType = classFile.thisType
+    val methodDescriptor = method.descriptor
+    val methodName = method.name
+    val body = method.body.get
+    val instructions = body.instructions
+    val maxPC = instructions.size
+
+    var currentPC = 0
+    while (currentPC < maxPC) {
+      val instruction = instructions(currentPC)
+
+      (instruction.opcode: @scala.annotation.switch) match {
+        case GETSTATIC.opcode ⇒
+          val GETSTATIC(declaringClass, fieldName, fieldType) = instruction
+          import project.resolveFieldReference
+          resolveFieldReference(declaringClass, fieldName, fieldType) match {
+
+            case Some(field) if field.isFinal ⇒
+            /* Nothing to do; constants do not impede purity! */
+
+            // case Some(field) if field.isPrivate /*&& field.isNonFinal*/ ⇒
+            // check if the field is effectively final
+
+            case _ ⇒
+              cellCompleter.putFinal(Impure)
+              return ;
+          }
+
+        case INVOKESPECIAL.opcode | INVOKESTATIC.opcode ⇒ instruction match {
+
+          case MethodInvocationInstruction(`declaringClassType`, _, `methodName`, `methodDescriptor`) ⇒
+          // We have a self-recursive call; such calls do not influence
+          // the computation of the method's purity and are ignored.
+          // Let's continue with the evaluation of the next instruction.
+
+          case mii: NonVirtualMethodInvocationInstruction ⇒
+
+            nonVirtualCall(mii) match {
+
+              case Success(callee) ⇒
+                /* Recall that self-recursive calls are handled earlier! */
+
+                val targetCellCompleter = methodToCellCompleter(callee)
+                hasDependencies = true
+                cellCompleter.cell.whenNext(targetCellCompleter.cell, (p: Purity, isFinal: Boolean) => if (isFinal && p == Impure) FinalOutcome(Impure) else NoOutcome)
+
+              case _ /* Empty or Failure */ ⇒
+
+                // We know nothing about the target method (it is not
+                // found in the scope of the current project).
+                cellCompleter.putFinal(Impure)
+                return ;
+            }
+
+        }
+
+        case NEW.opcode |
+          GETFIELD.opcode |
+          PUTFIELD.opcode | PUTSTATIC.opcode |
+          NEWARRAY.opcode | MULTIANEWARRAY.opcode | ANEWARRAY.opcode |
+          AALOAD.opcode | AASTORE.opcode |
+          BALOAD.opcode | BASTORE.opcode |
+          CALOAD.opcode | CASTORE.opcode |
+          SALOAD.opcode | SASTORE.opcode |
+          IALOAD.opcode | IASTORE.opcode |
+          LALOAD.opcode | LASTORE.opcode |
+          DALOAD.opcode | DASTORE.opcode |
+          FALOAD.opcode | FASTORE.opcode |
+          ARRAYLENGTH.opcode |
+          MONITORENTER.opcode | MONITOREXIT.opcode |
+          INVOKEDYNAMIC.opcode | INVOKEVIRTUAL.opcode | INVOKEINTERFACE.opcode ⇒
+          cellCompleter.putFinal(Impure)
+          return ;
+
+        case _ ⇒
+        /* All other instructions (IFs, Load/Stores, Arith., etc.) are pure. */
+      }
+      currentPC = body.pcOfNextInstruction(currentPC)
+    }
+
+    // Every method that is not identified as being impure is (conditionally)pure.
+    if (!hasDependencies) {
+      cellCompleter.putFinal(Pure)
+      //println("Immediately Pure Method: "+method.toJava(classFile))
+    }
+  }
+}

--- a/core/src/main/scala/opal/PurityAnalysis.scala
+++ b/core/src/main/scala/opal/PurityAnalysis.scala
@@ -1,209 +1,205 @@
-package opal
-
-import java.net.URL
-
-import scala.collection.JavaConverters._
-
-import scala.concurrent.Await
-import scala.concurrent.duration._
-
-import cell.{ HandlerPool, CellCompleter, Cell }
-import org.opalj.Success
-import org.opalj.br.{ ClassFile, PC, Method, MethodWithBody }
-import org.opalj.br.analyses.{ BasicReport, DefaultOneStepAnalysis, Project }
-import org.opalj.br.instructions.GETFIELD
-import org.opalj.br.instructions.GETSTATIC
-import org.opalj.br.instructions.PUTFIELD
-import org.opalj.br.instructions.PUTSTATIC
-import org.opalj.br.instructions.MONITORENTER
-import org.opalj.br.instructions.MONITOREXIT
-import org.opalj.br.instructions.NEW
-import org.opalj.br.instructions.NEWARRAY
-import org.opalj.br.instructions.MULTIANEWARRAY
-import org.opalj.br.instructions.ANEWARRAY
-import org.opalj.br.instructions.AALOAD
-import org.opalj.br.instructions.AASTORE
-import org.opalj.br.instructions.ARRAYLENGTH
-import org.opalj.br.instructions.LALOAD
-import org.opalj.br.instructions.IALOAD
-import org.opalj.br.instructions.CALOAD
-import org.opalj.br.instructions.BALOAD
-import org.opalj.br.instructions.BASTORE
-import org.opalj.br.instructions.CASTORE
-import org.opalj.br.instructions.IASTORE
-import org.opalj.br.instructions.LASTORE
-import org.opalj.br.instructions.SASTORE
-import org.opalj.br.instructions.SALOAD
-import org.opalj.br.instructions.DALOAD
-import org.opalj.br.instructions.FALOAD
-import org.opalj.br.instructions.FASTORE
-import org.opalj.br.instructions.DASTORE
-import org.opalj.br.instructions.INVOKEDYNAMIC
-import org.opalj.br.instructions.INVOKESTATIC
-import org.opalj.br.instructions.INVOKESPECIAL
-import org.opalj.br.instructions.INVOKEVIRTUAL
-import org.opalj.br.instructions.INVOKEINTERFACE
-import org.opalj.br.instructions.MethodInvocationInstruction
-import org.opalj.br.instructions.NonVirtualMethodInvocationInstruction
-
-object PurityAnalysis extends DefaultOneStepAnalysis {
-
-  override def doAnalyze(
-    project: Project[URL],
-    parameters: Seq[String] = List.empty,
-    isInterrupted: () ⇒ Boolean): BasicReport = {
-
-    val startTime = System.currentTimeMillis // Used for measuring execution time
-    // 1. Initialization of key data structures (one cell(completer) per method)
-    val pool = new HandlerPool()
-    var methodToCellCompleter = Map.empty[Method, CellCompleter[PurityKey.type, Purity]]
-    for {
-      classFile <- project.allProjectClassFiles
-      method <- classFile.methods
-    } {
-      val cellCompleter = CellCompleter[PurityKey.type, Purity](pool, PurityKey)
-      methodToCellCompleter = methodToCellCompleter + ((method, cellCompleter))
-    }
-
-    val middleTime = System.currentTimeMillis
-
-    // 2. trigger analyses
-    for {
-      classFile <- project.allProjectClassFiles.par
-      method <- classFile.methods
-    } {
-      pool.execute(() => analyze(project, methodToCellCompleter, classFile, method))
-    }
-    val fut = pool.quiescentResolveCell
-    Await.ready(fut, 30.minutes)
-    pool.shutdown()
-
-    val endTime = System.currentTimeMillis
-
-    val setupTime = middleTime - startTime
-    val analysisTime = endTime - middleTime
-    val combinedTime = endTime - startTime
-
-    val pureMethods = methodToCellCompleter.filter(_._2.cell.getResult match {
-      case Pure => true
-      case _ => false
-    }).map(_._1)
-
-    val pureMethodsInfo = pureMethods.map(m => m.toJava).toList.sorted
-
-    BasicReport("pure methods analysis:\n" + pureMethodsInfo.mkString("\n") +
-      s"\nSETUP TIME: $setupTime" +
-      s"\nANALYIS TIME: $analysisTime" +
-      s"\nCOMBINED TIME: $combinedTime")
-  }
-
-  /**
-   * Determines the purity of the given method.
-   */
-  def analyze(
-    project: Project[URL],
-    methodToCellCompleter: Map[Method, CellCompleter[PurityKey.type, Purity]],
-    classFile: ClassFile,
-    method: Method): Unit = {
-
-    import project.nonVirtualCall
-
-    val cellCompleter = methodToCellCompleter(method)
-
-    if ( // Due to a lack of knowledge, we classify all native methods or methods that
-    // belong to a library (and hence lack the body) as impure...
-    method.body.isEmpty /*HERE: method.isNative || "isLibraryMethod(method)"*/ ||
-      // for simplicity we are just focusing on methods that do not take objects as parameters
-      method.parameterTypes.exists(!_.isBaseType)) {
-      cellCompleter.putFinal(Impure)
-      return ;
-    }
-
-    var hasDependencies = false
-    val declaringClassType = classFile.thisType
-    val methodDescriptor = method.descriptor
-    val methodName = method.name
-    val body = method.body.get
-    val instructions = body.instructions
-    val maxPC = instructions.size
-
-    var currentPC = 0
-    while (currentPC < maxPC) {
-      val instruction = instructions(currentPC)
-
-      (instruction.opcode: @scala.annotation.switch) match {
-        case GETSTATIC.opcode ⇒
-          val GETSTATIC(declaringClass, fieldName, fieldType) = instruction
-          import project.resolveFieldReference
-          resolveFieldReference(declaringClass, fieldName, fieldType) match {
-
-            case Some(field) if field.isFinal ⇒
-            /* Nothing to do; constants do not impede purity! */
-
-            // case Some(field) if field.isPrivate /*&& field.isNonFinal*/ ⇒
-            // check if the field is effectively final
-
-            case _ ⇒
-              cellCompleter.putFinal(Impure)
-              return ;
-          }
-
-        case INVOKESPECIAL.opcode | INVOKESTATIC.opcode ⇒ instruction match {
-
-          case MethodInvocationInstruction(`declaringClassType`, _, `methodName`, `methodDescriptor`) ⇒
-          // We have a self-recursive call; such calls do not influence
-          // the computation of the method's purity and are ignored.
-          // Let's continue with the evaluation of the next instruction.
-
-          case mii: NonVirtualMethodInvocationInstruction ⇒
-
-            nonVirtualCall(mii) match {
-
-              case Success(callee) ⇒
-                /* Recall that self-recursive calls are handled earlier! */
-
-                val targetCellCompleter = methodToCellCompleter(callee)
-                hasDependencies = true
-                cellCompleter.cell.whenComplete(targetCellCompleter.cell, (p: Purity) => p == Impure, Impure)
-
-              case _ /* Empty or Failure */ ⇒
-
-                // We know nothing about the target method (it is not
-                // found in the scope of the current project).
-                cellCompleter.putFinal(Impure)
-                return ;
-            }
-
-        }
-
-        case NEW.opcode |
-          GETFIELD.opcode |
-          PUTFIELD.opcode | PUTSTATIC.opcode |
-          NEWARRAY.opcode | MULTIANEWARRAY.opcode | ANEWARRAY.opcode |
-          AALOAD.opcode | AASTORE.opcode |
-          BALOAD.opcode | BASTORE.opcode |
-          CALOAD.opcode | CASTORE.opcode |
-          SALOAD.opcode | SASTORE.opcode |
-          IALOAD.opcode | IASTORE.opcode |
-          LALOAD.opcode | LASTORE.opcode |
-          DALOAD.opcode | DASTORE.opcode |
-          FALOAD.opcode | FASTORE.opcode |
-          ARRAYLENGTH.opcode |
-          MONITORENTER.opcode | MONITOREXIT.opcode |
-          INVOKEDYNAMIC.opcode | INVOKEVIRTUAL.opcode | INVOKEINTERFACE.opcode ⇒
-          cellCompleter.putFinal(Impure)
-          return ;
-
-        case _ ⇒
-        /* All other instructions (IFs, Load/Stores, Arith., etc.) are pure. */
-      }
-      currentPC = body.pcOfNextInstruction(currentPC)
-    }
-
-    // Every method that is not identified as being impure is (conditionally)pure.
-    if (!hasDependencies) {
-      cellCompleter.putFinal(Pure)
-      //println("Immediately Pure Method: "+method.toJava(classFile))
-    }
-  }
-}
+//package opal
+//
+//import java.net.URL
+//
+//import scala.collection.JavaConverters._
+//import scala.concurrent.Await
+//import scala.concurrent.duration._
+//import cell._
+//import org.opalj.Success
+//import org.opalj.br.{ ClassFile, Method, MethodWithBody, PC }
+//import org.opalj.br.analyses.{ BasicReport, DefaultOneStepAnalysis, Project }
+//import org.opalj.br.instructions.GETFIELD
+//import org.opalj.br.instructions.GETSTATIC
+//import org.opalj.br.instructions.PUTFIELD
+//import org.opalj.br.instructions.PUTSTATIC
+//import org.opalj.br.instructions.MONITORENTER
+//import org.opalj.br.instructions.MONITOREXIT
+//import org.opalj.br.instructions.NEW
+//import org.opalj.br.instructions.NEWARRAY
+//import org.opalj.br.instructions.MULTIANEWARRAY
+//import org.opalj.br.instructions.ANEWARRAY
+//import org.opalj.br.instructions.AALOAD
+//import org.opalj.br.instructions.AASTORE
+//import org.opalj.br.instructions.ARRAYLENGTH
+//import org.opalj.br.instructions.LALOAD
+//import org.opalj.br.instructions.IALOAD
+//import org.opalj.br.instructions.CALOAD
+//import org.opalj.br.instructions.BALOAD
+//import org.opalj.br.instructions.BASTORE
+//import org.opalj.br.instructions.CASTORE
+//import org.opalj.br.instructions.IASTORE
+//import org.opalj.br.instructions.LASTORE
+//import org.opalj.br.instructions.SASTORE
+//import org.opalj.br.instructions.SALOAD
+//import org.opalj.br.instructions.DALOAD
+//import org.opalj.br.instructions.FALOAD
+//import org.opalj.br.instructions.FASTORE
+//import org.opalj.br.instructions.DASTORE
+//import org.opalj.br.instructions.INVOKEDYNAMIC
+//import org.opalj.br.instructions.INVOKESTATIC
+//import org.opalj.br.instructions.INVOKESPECIAL
+//import org.opalj.br.instructions.INVOKEVIRTUAL
+//import org.opalj.br.instructions.INVOKEINTERFACE
+//import org.opalj.br.instructions.MethodInvocationInstruction
+//import org.opalj.br.instructions.NonVirtualMethodInvocationInstruction
+//
+//object PurityAnalysis extends DefaultOneStepAnalysis {
+//
+//  override def doAnalyze(
+//    project: Project[URL],
+//    parameters: Seq[String] = List.empty,
+//    isInterrupted: () ⇒ Boolean): BasicReport = {
+//
+//    val startTime = System.currentTimeMillis // Used for measuring execution time
+//    // 1. Initialization of key data structures (one cell(completer) per method)
+//    val pool = new HandlerPool()
+//    var methodToCellCompleter = Map.empty[Method, CellCompleter[PurityKey.type, Purity]]
+//    for {
+//      classFile <- project.allProjectClassFiles
+//      method <- classFile.methods
+//    } {
+//      val cellCompleter = CellCompleter[PurityKey.type, Purity](pool, PurityKey)
+//      methodToCellCompleter = methodToCellCompleter + ((method, cellCompleter))
+//    }
+//
+//    val middleTime = System.currentTimeMillis
+//
+//    // 2. trigger analyses
+//    for {
+//      classFile <- project.allProjectClassFiles.par
+//      method <- classFile.methods
+//    } {
+//      pool.execute(() => analyze(project, methodToCellCompleter, classFile, method))
+//    }
+//    val fut = pool.quiescentResolveCell
+//    Await.ready(fut, 30.minutes)
+//    pool.shutdown()
+//
+//    val endTime = System.currentTimeMillis
+//
+//    val setupTime = middleTime - startTime
+//    val analysisTime = endTime - middleTime
+//    val combinedTime = endTime - startTime
+//
+//    val pureMethods = methodToCellCompleter.filter(_._2.cell.getResult match {
+//      case Pure => true
+//      case _ => false
+//    }).map(_._1)
+//
+//    val pureMethodsInfo = pureMethods.map(m => m.toJava("")).toList.sorted
+//
+//    BasicReport("pure methods analysis:\n" + pureMethodsInfo.mkString("\n") +
+//      s"\nSETUP TIME: $setupTime" +
+//      s"\nANALYIS TIME: $analysisTime" +
+//      s"\nCOMBINED TIME: $combinedTime")
+//  }
+//
+//  /**
+//   * Determines the purity of the given method.
+//   */
+//  def analyze(
+//    project: Project[URL],
+//    methodToCellCompleter: Map[Method, CellCompleter[PurityKey.type, Purity]],
+//    classFile: ClassFile,
+//    method: Method): Unit = {
+//
+//    val cellCompleter = methodToCellCompleter(method)
+//
+//    if ( // Due to a lack of knowledge, we classify all native methods or methods that
+//    // belong to a library (and hence lack the body) as impure...
+//    method.body.isEmpty /*HERE: method.isNative || "isLibraryMethod(method)"*/ ||
+//      // for simplicity we are just focusing on methods that do not take objects as parameters
+//      method.parameterTypes.exists(!_.isBaseType)) {
+//      cellCompleter.putFinal(Impure)
+//      return ;
+//    }
+//
+//    var hasDependencies = false
+//    val declaringClassType = classFile.thisType
+//    val methodDescriptor = method.descriptor
+//    val methodName = method.name
+//    val body = method.body.get
+//    val instructions = body.instructions
+//    val maxPC = instructions.size
+//
+//    var currentPC = 0
+//    while (currentPC < maxPC) {
+//      val instruction = instructions(currentPC)
+//
+//      (instruction.opcode: @scala.annotation.switch) match {
+//        case GETSTATIC.opcode ⇒
+//          val GETSTATIC(declaringClass, fieldName, fieldType) = instruction
+//          import project.resolveFieldReference
+//          resolveFieldReference(declaringClass, fieldName, fieldType) match {
+//
+//            case Some(field) if field.isFinal ⇒
+//            /* Nothing to do; constants do not impede purity! */
+//
+//            // case Some(field) if field.isPrivate /*&& field.isNonFinal*/ ⇒
+//            // check if the field is effectively final
+//
+//            case _ ⇒
+//              cellCompleter.putFinal(Impure)
+//              return ;
+//          }
+//
+//        case INVOKESPECIAL.opcode | INVOKESTATIC.opcode ⇒ instruction match {
+//
+//          case MethodInvocationInstruction(`declaringClassType`, _, `methodName`, `methodDescriptor`) ⇒
+//          // We have a self-recursive call; such calls do not influence
+//          // the computation of the method's purity and are ignored.
+//          // Let's continue with the evaluation of the next instruction.
+//
+//          case mii: NonVirtualMethodInvocationInstruction ⇒
+//
+//          //            nonVirtualCall(mii) match {
+//          //
+//          //              case Success(callee) ⇒
+//          //                /* Recall that self-recursive calls are handled earlier! */
+//          //                val targetCellCompleter = methodToCellCompleter(callee)
+//          //                hasDependencies = true
+//          //                cellCompleter.cell.whenNext(targetCellCompleter.cell, (p: Purity) => if(p == Impure)  WhenNextComplete else FalsePred, (_, isFinal) => if(isFinal) Some(Impure) else None)
+//          //
+//          //
+//          //              case _ /* Empty or Failure */ ⇒
+//          //
+//          //                // We know nothing about the target method (it is not
+//          //                // found in the scope of the current project).
+//          //                cellCompleter.putFinal(Impure)
+//          //                return ;
+//          //            }
+//
+//        }
+//
+//        case NEW.opcode |
+//          GETFIELD.opcode |
+//          PUTFIELD.opcode | PUTSTATIC.opcode |
+//          NEWARRAY.opcode | MULTIANEWARRAY.opcode | ANEWARRAY.opcode |
+//          AALOAD.opcode | AASTORE.opcode |
+//          BALOAD.opcode | BASTORE.opcode |
+//          CALOAD.opcode | CASTORE.opcode |
+//          SALOAD.opcode | SASTORE.opcode |
+//          IALOAD.opcode | IASTORE.opcode |
+//          LALOAD.opcode | LASTORE.opcode |
+//          DALOAD.opcode | DASTORE.opcode |
+//          FALOAD.opcode | FASTORE.opcode |
+//          ARRAYLENGTH.opcode |
+//          MONITORENTER.opcode | MONITOREXIT.opcode |
+//          INVOKEDYNAMIC.opcode | INVOKEVIRTUAL.opcode | INVOKEINTERFACE.opcode ⇒
+//          cellCompleter.putFinal(Impure)
+//          return ;
+//
+//        case _ ⇒
+//        /* All other instructions (IFs, Load/Stores, Arith., etc.) are pure. */
+//      }
+//      currentPC = body.pcOfNextInstruction(currentPC)
+//    }
+//
+//    // Every method that is not identified as being impure is (conditionally)pure.
+//    if (!hasDependencies) {
+//      cellCompleter.putFinal(Pure)
+//      //println("Immediately Pure Method: "+method.toJava(classFile))
+//    }
+//  }
+//}

--- a/core/src/test/scala/cell/base.scala
+++ b/core/src/test/scala/cell/base.scala
@@ -10,19 +10,14 @@ import scala.concurrent.duration._
 
 import lattice.{ Lattice, StringIntLattice, LatticeViolationException, StringIntKey }
 
-//import org.opalj.fpcf.analyses.FieldMutabilityAnalysis
-//import org.opalj.fpcf.properties.FieldMutability
-//import org.opalj.fpcf.FPCFAnalysesManager
-//import org.opalj.fpcf.FPCFAnalysis
-//import org.opalj.fpcf.FPCFAnalysesManagerKey
-//import org.opalj.fpcf.analyses.FieldMutabilityAnalysis
+import org.opalj.fpcf.analyses.FieldMutabilityAnalysis
 import org.opalj.fpcf.properties.FieldMutability
 import org.opalj.fpcf.FPCFAnalysesManager
 import org.opalj.fpcf.FPCFAnalysis
 import org.opalj.fpcf.FPCFAnalysesManagerKey
 import opal._
-//import org.opalj.br.analyses.Project
-//import java.io.File
+import org.opalj.br.analyses.Project
+import java.io.File
 
 class BaseSuite extends FunSuite {
 
@@ -215,7 +210,7 @@ class BaseSuite extends FunSuite {
     pool.shutdown()
   }
 
-  test("whenNext 2") {
+  test("whenNext: again") {
     val latch = new CountDownLatch(1)
 
     val pool = new HandlerPool
@@ -712,62 +707,62 @@ class BaseSuite extends FunSuite {
     assert(res == ConditionallyImmutable)
   }
 
-  //  test("purity analysis with Demo.java: pure methods") {
-  //    val file = new File("core")
-  //    val lib = Project(file)
-  //
-  //    val report = PurityAnalysis.doAnalyze(lib, List.empty, () => false).toConsoleString.split("\n")
-  //
-  //    val pureMethods = List(
-  //      "pureness.Demo{ public static int pureThoughItUsesField(int,int) }",
-  //      "pureness.Demo{ public static int pureThoughItUsesField2(int,int) }",
-  //      "pureness.Demo{ public static int simplyPure(int,int) }",
-  //      "pureness.Demo{ static int foo(int) }",
-  //      "pureness.Demo{ static int bar(int) }",
-  //      "pureness.Demo{ static int fooBar(int) }",
-  //      "pureness.Demo{ static int barFoo(int) }",
-  //      "pureness.Demo{ static int m1(int) }",
-  //      "pureness.Demo{ static int m2(int) }",
-  //      "pureness.Demo{ static int m3(int) }",
-  //      "pureness.Demo{ static int cm1(int) }",
-  //      "pureness.Demo{ static int cm2(int) }",
-  //      "pureness.Demo{ static int scc0(int) }",
-  //      "pureness.Demo{ static int scc1(int) }",
-  //      "pureness.Demo{ static int scc2(int) }",
-  //      "pureness.Demo{ static int scc3(int) }")
-  //
-  //    val finalRes = pureMethods.filter(!report.contains(_))
-  //
-  //    assert(finalRes.size == 0, report.mkString("\n"))
-  //  }
-  //
-  //  test("purity analysis with Demo.java: impure methods") {
-  //    val file = new File("core")
-  //    val lib = Project(file)
-  //
-  //    val report = PurityAnalysis.doAnalyze(lib, List.empty, () => false).toConsoleString.split("\n")
-  //
-  //    val impureMethods = List(
-  //      "public static int impure(int)",
-  //      "static int npfoo(int)",
-  //      "static int npbar(int)",
-  //      "static int mm1(int)",
-  //      "static int mm2(int)",
-  //      "static int mm3(int)",
-  //      "static int m1np(int)",
-  //      "static int m2np(int)",
-  //      "static int m3np(int)",
-  //      "static int cpure(int)",
-  //      "static int cpureCallee(int)",
-  //      "static int cpureCalleeCallee1(int)",
-  //      "static int cpureCalleeCallee2(int)",
-  //      "static int cpureCalleeCalleeCallee(int)",
-  //      "static int cpureCalleeCalleeCalleeCallee(int)")
-  //
-  //    val finalRes = impureMethods.filter(report.contains(_))
-  //
-  //    assert(finalRes.size == 0)
-  //  }
+  test("purity analysis with Demo.java: pure methods") {
+    val file = new File("core")
+    val lib = Project(file)
+
+    val report = PurityAnalysis.doAnalyze(lib, List.empty, () => false).toConsoleString.split("\n")
+
+    val pureMethods = List(
+      "pureness.Demo{ public static int pureThoughItUsesField(int,int) }",
+      "pureness.Demo{ public static int pureThoughItUsesField2(int,int) }",
+      "pureness.Demo{ public static int simplyPure(int,int) }",
+      "pureness.Demo{ static int foo(int) }",
+      "pureness.Demo{ static int bar(int) }",
+      "pureness.Demo{ static int fooBar(int) }",
+      "pureness.Demo{ static int barFoo(int) }",
+      "pureness.Demo{ static int m1(int) }",
+      "pureness.Demo{ static int m2(int) }",
+      "pureness.Demo{ static int m3(int) }",
+      "pureness.Demo{ static int cm1(int) }",
+      "pureness.Demo{ static int cm2(int) }",
+      "pureness.Demo{ static int scc0(int) }",
+      "pureness.Demo{ static int scc1(int) }",
+      "pureness.Demo{ static int scc2(int) }",
+      "pureness.Demo{ static int scc3(int) }")
+
+    val finalRes = pureMethods.filter(!report.contains(_))
+
+    assert(finalRes.size == 0, report.mkString("\n"))
+  }
+
+  test("purity analysis with Demo.java: impure methods") {
+    val file = new File("core")
+    val lib = Project(file)
+
+    val report = PurityAnalysis.doAnalyze(lib, List.empty, () => false).toConsoleString.split("\n")
+
+    val impureMethods = List(
+      "public static int impure(int)",
+      "static int npfoo(int)",
+      "static int npbar(int)",
+      "static int mm1(int)",
+      "static int mm2(int)",
+      "static int mm3(int)",
+      "static int m1np(int)",
+      "static int m2np(int)",
+      "static int m3np(int)",
+      "static int cpure(int)",
+      "static int cpureCallee(int)",
+      "static int cpureCalleeCallee1(int)",
+      "static int cpureCalleeCallee2(int)",
+      "static int cpureCalleeCalleeCallee(int)",
+      "static int cpureCalleeCalleeCalleeCallee(int)")
+
+    val finalRes = impureMethods.filter(report.contains(_))
+
+    assert(finalRes.size == 0)
+  }
 
   test("PurityLattice: successful joins") {
     val lattice = Purity.PurityLattice

--- a/core/src/test/scala/cell/base.scala
+++ b/core/src/test/scala/cell/base.scala
@@ -15,6 +15,11 @@ import lattice.{ Lattice, StringIntLattice, LatticeViolationException, StringInt
 //import org.opalj.fpcf.FPCFAnalysesManager
 //import org.opalj.fpcf.FPCFAnalysis
 //import org.opalj.fpcf.FPCFAnalysesManagerKey
+//import org.opalj.fpcf.analyses.FieldMutabilityAnalysis
+import org.opalj.fpcf.properties.FieldMutability
+import org.opalj.fpcf.FPCFAnalysesManager
+import org.opalj.fpcf.FPCFAnalysis
+import org.opalj.fpcf.FPCFAnalysesManagerKey
 import opal._
 //import org.opalj.br.analyses.Project
 //import java.io.File

--- a/core/src/test/scala/cell/base.scala
+++ b/core/src/test/scala/cell/base.scala
@@ -292,7 +292,7 @@ class BaseSuite extends FunSuite {
       else NoOutcome
     )
 
-    assert(cell1.numDependencies == 1)
+    assert(cell1.numDependencies == 2)
 
     cell1.onComplete {
       case Success(x) =>
@@ -303,8 +303,10 @@ class BaseSuite extends FunSuite {
         latch.countDown()
     }
     cell1.onNext {
-      case (Success(x), _) =>
-        assert(false)
+      case (Success(x), true) =>
+        assert(x === 20)
+      case (Success(x), false) =>
+        assert(x === 30)
       case (Failure(e), _) =>
         assert(false)
     }

--- a/core/src/test/scala/internalBase.scala
+++ b/core/src/test/scala/internalBase.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 
 import lattice._
 
-import opal.PurityAnalysis
+//import opal.PurityAnalysis
 import org.opalj.br.analyses.Project
 
 class InternalBaseSuite extends FunSuite {
@@ -24,11 +24,11 @@ class InternalBaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "key2")
     val cell1 = completer1.cell
     val cell2 = completer2.cell
-    cell1.whenComplete(cell2, (x: Int) => x == 0, 0)
-    cell1.whenComplete(cell2, (x: Int) => x == 0, 0)
+    cell1.whenNext(cell2, (x, isFinal) => if (isFinal && x == 0) FinalOutcome(0) else NoOutcome)
+    cell1.whenNext(cell2, (x, isFinal) => if (isFinal && x == 0) FinalOutcome(0) else NoOutcome)
 
-    assert(cell1.numCompleteDependencies == 2)
-    assert(cell2.numCompleteDependencies == 0)
+    assert(cell1.numDependencies == 2)
+    assert(cell2.numDependencies == 0)
   }
 
   test("cellDependencies: By removing dependencies") {
@@ -37,12 +37,12 @@ class InternalBaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "key2")
     val cell1 = completer1.cell
     val cell2 = completer2.cell
-    cell1.whenComplete(cell2, (x: Int) => x == 0, 0)
-    cell1.whenComplete(cell2, (x: Int) => x == 0, 0)
+    cell1.whenNext(cell2, (x, isFinal) => if (isFinal && x == 0) FinalOutcome(0) else NoOutcome)
+    cell1.whenNext(cell2, (x, isFinal) => if (isFinal && x == 0) FinalOutcome(0) else NoOutcome)
 
     completer1.putFinal(0)
 
-    assert(cell1.numCompleteDependencies == 0)
-    assert(cell2.numCompleteDependencies == 0)
+    assert(cell1.numDependencies == 0)
+    assert(cell2.numDependencies == 0)
   }
 }


### PR DESCRIPTION
- Remove whenComplete in favour of a boolean parameter to the valueCallback to indicate, if the new value is value. The same parameter is used for onNext callbacks.

- Remove `pred` from whenNext. Instead, the valueCallback returns an instance of WhenNextOutcome[V], i.e. the new value for a cell and whether this value is final.
