### PR TITLE
Redefine whenNext

### DIFF
--- a/core/src/main/scala/cell/CellCompleter.scala
+++ b/core/src/main/scala/cell/CellCompleter.scala
@@ -22,7 +22,6 @@ trait CellCompleter[K <: Key[V], V] {
   def tryComplete(value: Try[V]): Boolean
 
   private[cell] def removeDep(cell: Cell[K, V]): Unit
-  private[cell] def removeNextDep(cell: Cell[K, V]): Unit
 }
 
 object CellCompleter {

--- a/core/src/main/scala/cell/HandlerPool.scala
+++ b/core/src/main/scala/cell/HandlerPool.scala
@@ -87,7 +87,7 @@ class HandlerPool(parallelism: Int = 8, unhandledExceptionHandler: Throwable => 
       val registered: Seq[Cell[K, V]] = this.cellsNotDone.get().values.asInstanceOf[Iterable[Cell[K, V]]].toSeq
       println(registered.size)
       if (registered.nonEmpty) {
-        val cSCCs = closedSCCs(registered, (cell: Cell[K, V]) => cell.totalCellDependencies)
+        val cSCCs = closedSCCs(registered, (cell: Cell[K, V]) => cell.cellDependencies)
         cSCCs.foreach(cSCC => resolveCycle(cSCC.asInstanceOf[Seq[Cell[K, V]]]))
       }
       p.success(true)
@@ -114,7 +114,7 @@ class HandlerPool(parallelism: Int = 8, unhandledExceptionHandler: Throwable => 
       // Find one closed strongly connected component (cell)
       val registered: Seq[Cell[K, V]] = this.cellsNotDone.get().values.asInstanceOf[Iterable[Cell[K, V]]].toSeq
       if (registered.nonEmpty) {
-        val cSCCs = closedSCCs(registered, (cell: Cell[K, V]) => cell.totalCellDependencies)
+        val cSCCs = closedSCCs(registered, (cell: Cell[K, V]) => cell.cellDependencies)
         cSCCs.foreach(cSCC => resolveCycle(cSCC.asInstanceOf[Seq[Cell[K, V]]]))
       }
       // Finds the rest of the unresolved cells

--- a/core/src/main/scala/opal/PurityAnalysis.scala
+++ b/core/src/main/scala/opal/PurityAnalysis.scala
@@ -3,13 +3,11 @@ package opal
 import java.net.URL
 
 import scala.collection.JavaConverters._
-
 import scala.concurrent.Await
 import scala.concurrent.duration._
-
-import cell.{ HandlerPool, CellCompleter, Cell }
+import cell._
 import org.opalj.Success
-import org.opalj.br.{ ClassFile, PC, Method, MethodWithBody }
+import org.opalj.br.{ ClassFile, Method, MethodWithBody, PC }
 import org.opalj.br.analyses.{ BasicReport, DefaultOneStepAnalysis, Project }
 import org.opalj.br.instructions.GETFIELD
 import org.opalj.br.instructions.GETSTATIC
@@ -164,7 +162,7 @@ object PurityAnalysis extends DefaultOneStepAnalysis {
 
                 val targetCellCompleter = methodToCellCompleter(callee)
                 hasDependencies = true
-                cellCompleter.cell.whenComplete(targetCellCompleter.cell, (p: Purity) => p == Impure, Impure)
+                cellCompleter.cell.whenNext(targetCellCompleter.cell, (p: Purity, isFinal: Boolean) => if (isFinal && p == Impure) FinalOutcome(Impure) else NoOutcome)
 
               case _ /* Empty or Failure */ ⇒
 

--- a/core/src/test/scala/cell/base.scala
+++ b/core/src/test/scala/cell/base.scala
@@ -1,20 +1,14 @@
 package cell
 
 import org.scalatest.FunSuite
-
 import java.util.concurrent.CountDownLatch
 
-import scala.util.{ Success, Failure }
-import scala.concurrent.{ Promise, Await }
+import scala.util.{ Failure, Success, Try }
+import scala.concurrent.{ Await, Promise }
 import scala.concurrent.duration._
 
 import lattice.{ Lattice, StringIntLattice, LatticeViolationException, StringIntKey }
 
-import org.opalj.fpcf.analyses.FieldMutabilityAnalysis
-import org.opalj.fpcf.properties.FieldMutability
-import org.opalj.fpcf.FPCFAnalysesManager
-import org.opalj.fpcf.FPCFAnalysis
-import org.opalj.fpcf.FPCFAnalysesManagerKey
 import opal._
 import org.opalj.br.analyses.Project
 import java.io.File
@@ -97,7 +91,7 @@ class BaseSuite extends FunSuite {
     pool.shutdown()
   }
 
-  test("whenComplete") {
+  test("whenNext") {
     val latch = new CountDownLatch(1)
 
     val pool = new HandlerPool
@@ -105,7 +99,10 @@ class BaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "someotherkey")
 
     val cell1 = completer1.cell
-    cell1.whenComplete(completer2.cell, (x: Int) => x == 10, 20)
+    cell1.whenNext(completer2.cell, (x: Int, isFinal: Boolean) =>
+      if ((x == 10) && (isFinal)) FinalOutcome(20)
+      else NoOutcome
+    )
 
     cell1.onComplete {
       case Success(v) =>
@@ -131,7 +128,10 @@ class BaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "someotherkey")
 
     val cell1 = completer1.cell
-    cell1.whenComplete(completer2.cell, (x: Int) => x == 10, 20)
+    cell1.whenNext(completer2.cell, (x, isFinal) =>
+      if(isFinal && x == 10) FinalOutcome(20)
+      else NoOutcome
+    )
 
     cell1.onComplete {
       case Success(v) =>
@@ -146,7 +146,7 @@ class BaseSuite extends FunSuite {
 
     latch.await()
 
-    assert(cell1.numCompleteDependencies == 0)
+    assert(cell1.numDependencies == 0)
 
     pool.shutdown()
   }
@@ -157,13 +157,16 @@ class BaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "someotherkey")
 
     val cell1 = completer1.cell
-    cell1.whenComplete(completer2.cell, (x: Int) => x == 10, 20)
+    cell1.whenNext(completer2.cell, (x, isFinal) =>
+      if(isFinal && x == 10) FinalOutcome(20)
+      else NoOutcome
+    )
 
     completer2.putFinal(9)
 
     cell1.waitUntilNoDeps()
 
-    assert(cell1.numCompleteDependencies == 0)
+    assert(cell1.numDependencies == 0)
 
     pool.shutdown()
   }
@@ -174,7 +177,10 @@ class BaseSuite extends FunSuite {
     val completer1 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
     val completer2 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
 
-    completer1.cell.whenComplete(completer2.cell, (imm: Immutability) => imm == Mutable, Mutable)
+    completer1.cell.whenNext(completer2.cell, (imm: Immutability, isFinal: Boolean) =>
+      if (imm == Mutable) FinalOutcome(Mutable)
+      else NoOutcome
+    )
 
     completer1.putFinal(Immutable)
     assert(completer2.cell.numCompleteCallbacks == 0)
@@ -194,14 +200,14 @@ class BaseSuite extends FunSuite {
 
     val cell = completer.cell
 
-    cell.onNext {
+    cell.onNext((v, _) => v match {
       case Success(x) =>
         assert(x === 9)
         latch.countDown()
       case Failure(e) =>
         assert(false)
         latch.countDown()
-    }
+    })
 
     completer.putNext(9)
 
@@ -210,7 +216,7 @@ class BaseSuite extends FunSuite {
     pool.shutdown()
   }
 
-  test("whenNext") {
+  test("whenNext: final") {
     val latch = new CountDownLatch(1)
 
     val pool = new HandlerPool
@@ -218,16 +224,16 @@ class BaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "someotherkey")
 
     val cell1 = completer1.cell
-    cell1.whenNext(completer2.cell, (x: Int) => {
-      if (x == 10) WhenNext
-      else FalsePred
-    }, 20)
+    cell1.whenNext(completer2.cell, (x: Int, isFinal: Boolean) => {
+      if (x == 10) NextOutcome(20)
+      else NoOutcome
+    })
 
     cell1.onNext {
-      case Success(x) =>
+      case (Success(x), _) =>
         assert(x === 20)
         latch.countDown()
-      case Failure(e) =>
+      case (Failure(e), _) =>
         assert(false)
         latch.countDown()
     }
@@ -235,7 +241,7 @@ class BaseSuite extends FunSuite {
     completer2.putNext(10)
     latch.await()
 
-    assert(cell1.numNextDependencies == 1)
+    assert(cell1.numDependencies == 1)
 
     pool.shutdown()
   }
@@ -248,16 +254,16 @@ class BaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "someotherkey")
 
     val cell1 = completer1.cell
-    cell1.whenNext(completer2.cell, (x: Int) => {
-      if (x == 10) WhenNext
-      else FalsePred
-    }, 20)
+    cell1.whenNext(completer2.cell, (x: Int, isFinal: Boolean) => {
+      if (x == 10) NextOutcome(20)
+      else NoOutcome
+    })
 
     cell1.onNext {
-      case Success(x) =>
+      case (Success(x), _) =>
         assert(x === 8)
         latch.countDown()
-      case Failure(e) =>
+      case (Failure(e), _) =>
         assert(false)
         latch.countDown()
     }
@@ -278,13 +284,16 @@ class BaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "someotherkey")
 
     val cell1 = completer1.cell
-    cell1.whenNext(completer2.cell, (x: Int) => {
-      if (x == 10) WhenNext
-      else FalsePred
-    }, 30)
-    cell1.whenComplete(completer2.cell, (x: Int) => x == 10, 20)
+    cell1.whenNext(completer2.cell, (x: Int, _) => {
+      if (x == 10) NextOutcome(30)
+      else NoOutcome
+    })
+    cell1.whenNext(completer2.cell, (x, isFinal) =>
+      if (isFinal && x == 10) FinalOutcome(20)
+      else NoOutcome
+    )
 
-    assert(cell1.numNextDependencies == 1)
+    assert(cell1.numDependencies == 2)
 
     cell1.onComplete {
       case Success(x) =>
@@ -295,16 +304,18 @@ class BaseSuite extends FunSuite {
         latch.countDown()
     }
     cell1.onNext {
-      case Success(x) =>
-        assert(false)
-      case Failure(e) =>
+      case (Success(x), true) =>
+        assert(x === 20)
+      case (Success(x), false) =>
+        assert(x === 30)
+      case (Failure(e), _) =>
         assert(false)
     }
 
     completer2.putFinal(10)
     latch.await()
 
-    assert(cell1.numNextDependencies == 0)
+    assert(cell1.numDependencies == 0)
 
     pool.shutdown()
   }
@@ -317,18 +328,18 @@ class BaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "someotherkey")
 
     val cell1 = completer1.cell
-    cell1.whenNext(completer2.cell, (x: Int) => {
-      if (x == 10) WhenNext
-      else FalsePred
-    }, 20)
+    cell1.whenNext(completer2.cell, (x: Int, _) => {
+      if (x == 10) NextOutcome(20)
+      else NoOutcome
+    })
 
-    assert(cell1.numNextDependencies == 1)
+    assert(cell1.numDependencies == 1)
 
     cell1.onNext {
-      case Success(x) =>
+      case (Success(x), _) =>
         assert(x === 20)
         latch.countDown()
-      case Failure(e) =>
+      case (Failure(e), _) =>
         assert(false)
         latch.countDown()
     }
@@ -346,16 +357,16 @@ class BaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "someotherkey")
 
     val cell1 = completer1.cell
-    cell1.whenNext(completer2.cell, (x: Int) => {
-      if (x == 10) WhenNext
-      else FalsePred
-    }, 20)
+    cell1.whenNext(completer2.cell, (x: Int, _) => {
+      if (x == 10) NextOutcome(20)
+      else NoOutcome
+    })
 
     completer2.putFinal(10)
 
-    cell1.waitUntilNoNextDeps()
+    cell1.waitUntilNoDeps()
 
-    assert(cell1.numNextDependencies == 0)
+    assert(cell1.numDependencies == 0)
 
     pool.shutdown()
   }
@@ -366,10 +377,10 @@ class BaseSuite extends FunSuite {
     val completer1 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
     val completer2 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
 
-    completer1.cell.whenNext(completer2.cell, (imm: Immutability) => imm match {
-      case Mutable => WhenNext
-      case _ => FalsePred
-    }, Mutable)
+    completer1.cell.whenNext(completer2.cell, (imm: Immutability, _) => imm match {
+      case Mutable => NextOutcome(Mutable)
+      case _ => NoOutcome
+    })
 
     completer1.putFinal(Immutable)
     assert(completer2.cell.numNextCallbacks == 0)
@@ -389,16 +400,17 @@ class BaseSuite extends FunSuite {
 
     for (i <- 1 to 10000) {
       pool.execute(() => {
-        completer1.cell.whenNext(completer2.cell, (x: Immutability) => {
-          if (x == Mutable) WhenNext else FalsePred
-        }, Mutable)
+        completer1.cell.whenNext(completer2.cell, (x: Immutability, _) => {
+          if (x == Mutable) NextOutcome(Mutable)
+          else NoOutcome
+        })
         latch.countDown()
       })
     }
 
     latch.await()
 
-    assert(completer1.cell.numNextDependencies == 10000)
+    assert(completer1.cell.numDependencies == 10000)
 
     pool.shutdown()
   }
@@ -409,12 +421,12 @@ class BaseSuite extends FunSuite {
     for (i <- 1 to 1000) {
       val completer1 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
       val completer2 = CellCompleter[ImmutabilityKey.type, Immutability](pool, ImmutabilityKey)
-      completer1.cell.whenNext(completer2.cell, (imm: Immutability) => imm match {
-        case Immutable | ConditionallyImmutable => FalsePred
-        case Mutable => WhenNext
-      }, Mutable)
+      completer1.cell.whenNext(completer2.cell, (imm: Immutability, _) => imm match {
+        case Immutable | ConditionallyImmutable => NoOutcome
+        case Mutable => NextOutcome(Mutable)
+      })
 
-      assert(completer1.cell.numTotalDependencies == 1)
+      assert(completer1.cell.numDependencies == 1)
 
       pool.execute(() => completer2.putNext(ConditionallyImmutable))
       pool.execute(() => completer2.putFinal(Mutable))
@@ -437,10 +449,10 @@ class BaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "someotherkey")
 
     val cell1 = completer1.cell
-    cell1.whenNext(completer2.cell, (x: Int) => {
-      if (x == 10) WhenNextComplete
-      else FalsePred
-    }, 20)
+    cell1.whenNext(completer2.cell, (x: Int, _) => {
+      if (x == 10) FinalOutcome(20)
+      else NoOutcome
+    })
 
     cell1.onComplete {
       case Success(v) =>
@@ -476,10 +488,10 @@ class BaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "someotherkey")
 
     val cell1 = completer1.cell
-    cell1.whenNext(completer2.cell, (x: Int) => {
-      if (x == 10) WhenNextComplete
-      else FalsePred
-    }, 20)
+    cell1.whenNext(completer2.cell, (x: Int, _) => {
+      if (x == 10) FinalOutcome(20)
+      else NoOutcome
+    })
 
     cell1.onComplete {
       case Success(x) =>
@@ -507,19 +519,24 @@ class BaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "someotherkey")
 
     val cell1 = completer1.cell
-    cell1.whenNext(completer2.cell, (x: Int) => {
-      if (x == 10) WhenNextComplete
-      else FalsePred
-    }, 20)
+    cell1.whenNext(completer2.cell, (x: Int, _) => {
+      if (x == 10) FinalOutcome(20)
+      else NoOutcome
+    })
 
-    cell1.onNext {
-      case Success(x) =>
-        assert(x === 8)
-        latch1.countDown()
-      case Failure(e) =>
-        assert(false)
-        latch1.countDown()
-    }
+    cell1.onNext(
+      (v: Try[Int], isFinal: Boolean) =>
+        (v, isFinal) match {
+          case (Success(x), false) =>
+            assert(x === 8)
+            latch1.countDown()
+          case (Success(x), true) =>
+            assert(x === 20)
+          /* also handled by `onComplete` */
+          case (Failure(e), _) =>
+            assert(false)
+            latch1.countDown()
+        })
 
     cell1.onComplete {
       case Success(x) =>
@@ -537,6 +554,9 @@ class BaseSuite extends FunSuite {
     latch2.await()
 
     pool.shutdown()
+
+    assert(cell1.getResult() == 20)
+    assert(completer2.cell.getResult() == 10)
   }
 
   test("put: isFinal == true") {
@@ -564,10 +584,10 @@ class BaseSuite extends FunSuite {
     val pool = new HandlerPool
     val completer = CellCompleter[StringIntKey, Int](pool, "somekey")
     completer.cell.onNext {
-      case Success(x) =>
+      case (Success(x), _) =>
         assert(x === 10)
         latch.countDown()
-      case Failure(e) =>
+      case (Failure(e), _) =>
         assert(false)
         latch.countDown()
     }
@@ -618,10 +638,10 @@ class BaseSuite extends FunSuite {
     val cell = completer.cell
     completer.putNext(Set(3, 5))
     cell.onNext {
-      case Success(v) =>
+      case (Success(v), _) =>
         assert(v === Set(3, 4, 5))
         latch.countDown()
-      case Failure(e) =>
+      case (Failure(e), _) =>
         assert(false)
         latch.countDown()
     }
@@ -651,8 +671,14 @@ class BaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "key2")
     val cell1 = completer1.cell
     val cell2 = completer2.cell
-    cell1.whenComplete(cell2, (x: Int) => x == 1, 1)
-    cell2.whenComplete(cell1, (x: Int) => x == 1, 1)
+    cell1.whenNext(cell2, (x: Int, isFinal: Boolean) =>
+      if (isFinal && x == 1) FinalOutcome(1)
+      else NoOutcome
+    )
+    cell2.whenNext(cell1, (x: Int, isFinal: Boolean) =>
+      if (isFinal && x == 1) FinalOutcome(1)
+      else NoOutcome
+    )
     val incompleteFut = pool.quiescentIncompleteCells
     val cells = Await.result(incompleteFut, 2.seconds)
     assert(cells.map(_.key).toString == "List(key1, key2)")
@@ -664,8 +690,14 @@ class BaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "key2")
     val cell1 = completer1.cell
     val cell2 = completer2.cell
-    cell1.whenComplete(cell2, (x: Int) => x == 0, 0)
-    cell2.whenComplete(cell1, (x: Int) => x == 0, 0)
+    cell1.whenNext(cell2, (x, isFinal) =>
+      if (isFinal && x == 0) FinalOutcome(0)
+        else NoOutcome
+    )
+    cell2.whenNext(cell1, (x, isFinal) =>
+      if (isFinal && x == 0) FinalOutcome(0)
+      else NoOutcome
+    )
     val qfut = pool.quiescentResolveCell
     Await.ready(qfut, 2.seconds)
     val incompleteFut = pool.quiescentIncompleteCells

--- a/core/src/test/scala/internalBase.scala
+++ b/core/src/test/scala/internalBase.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 
 import lattice._
 
-import opal.PurityAnalysis
+//import opal.PurityAnalysis
 import org.opalj.br.analyses.Project
 
 class InternalBaseSuite extends FunSuite {
@@ -24,11 +24,11 @@ class InternalBaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "key2")
     val cell1 = completer1.cell
     val cell2 = completer2.cell
-    cell1.whenComplete(cell2, (x: Int) => x == 0, 0)
-    cell1.whenComplete(cell2, (x: Int) => x == 0, 0)
+    cell1.whenNext(cell2, (x, isFinal) => if (isFinal && x == 0) FinalOutcome(0) else NoOutcome)
+    cell1.whenNext(cell2, (x, isFinal) => if (isFinal && x == 0) FinalOutcome(0) else NoOutcome)
 
-    assert(cell1.numCompleteDependencies == 2)
-    assert(cell2.numCompleteDependencies == 0)
+    assert(cell1.numDependencies == 2)
+    assert(cell2.numDependencies == 0)
   }
 
   test("cellDependencies: By removing dependencies") {
@@ -37,12 +37,12 @@ class InternalBaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "key2")
     val cell1 = completer1.cell
     val cell2 = completer2.cell
-    cell1.whenComplete(cell2, (x: Int) => x == 0, 0)
-    cell1.whenComplete(cell2, (x: Int) => x == 0, 0)
+    cell1.whenNext(cell2, (x, isFinal) => if (isFinal && x == 0) FinalOutcome(0) else NoOutcome)
+    cell1.whenNext(cell2, (x, isFinal) => if (isFinal && x == 0) FinalOutcome(0) else NoOutcome)
 
     completer1.putFinal(0)
 
-    assert(cell1.numCompleteDependencies == 0)
-    assert(cell2.numCompleteDependencies == 0)
+    assert(cell1.numDependencies == 0)
+    assert(cell2.numDependencies == 0)
   }
 }


### PR DESCRIPTION
(1) Remove whenComplete in favour of a boolean parameter to the valueCallback to indicate, if the new value is value. The same parameter is used for onNext callbacks.
(2) Remove `pred` from whenNext. Instead, the valueCallback returns an instance of WhenNextOutcome[V], i.e. the new value for a cell and whether this value is final.
(3) Adapt tests according to those changes.