### PR TITLE
Replace `WhenNextPred` by `Outcome`.

### DIFF
--- a/core/src/main/scala/cell/outcome.scala
+++ b/core/src/main/scala/cell/outcome.scala
@@ -1,0 +1,41 @@
+package cell
+
+/** Use this trait in callbacks to return the new value of a cell.
+  * `NextOutcome(v)` and `FinalOutcome(v)` put the value `v` to
+  * the cell, in the latter case, the cell is completed.
+  * Use `NoOutcome` to indicate that no progress is possible.
+  */
+sealed trait Outcome[+V]
+case class NextOutcome[+V](x: V) extends Outcome[V]
+case class FinalOutcome[+V](x: V) extends Outcome[V]
+case object NoOutcome extends Outcome[Nothing]
+
+object Outcome {
+
+  /** Returns a `NextOutcome(v)` or `FinalOutcome(v)` object. */
+  def apply[V](v: V, isFinal: Boolean): Outcome[V] = {
+    if (isFinal) FinalOutcome(v)
+    else NextOutcome(v)
+  }
+
+  /** Returns a `NextOutcome(v)` or `FinalOutcome(v)` or `NoOutcome` object.
+    *
+    * If `v` is `None`, `NoOutcome` is returned. Otherwise, `NextOutcome(v)` or
+    * `FinalOutcome(v)` is returned depending on `isFinal`.
+    *
+    * @param v Option of a new value.
+    * @param isFinal Indicates if the value is final.
+    * @return Returns a `NextOutcome(v)` or `FinalOutcome(v)` or `NoOutcome` object.
+    */
+  def apply[V](v: Option[V], isFinal: Boolean): Outcome[V] = {
+    if (isFinal) v.map(FinalOutcome(_)).getOrElse(NoOutcome)
+    else v.map(NextOutcome(_)).getOrElse(NoOutcome)
+  }
+
+  /** Match non-empty outcomes. */
+  def unapply[V](arg: Outcome[V]): Option[(V, Boolean)] = arg match {
+    case FinalOutcome(v) => Some(v, true)
+    case NextOutcome(v) => Some(v, false)
+    case _ => None
+  }
+}

--- a/core/src/main/scala/opal/ImmutabilityAnalysis.scala
+++ b/core/src/main/scala/opal/ImmutabilityAnalysis.scala
@@ -261,10 +261,9 @@ object ImmutabilityAnalysis extends DefaultOneStepAnalysis {
                   cellCompleter.cell.whenNext(
                     fieldTypeCell,
                     (fieldImm: Immutability) => fieldImm match {
-                      case Mutable | ConditionallyImmutable => WhenNext
-                      case Immutable => FalsePred
-                    },
-                    ConditionallyImmutable)
+                      case Mutable | ConditionallyImmutable => NextOutcome(ConditionallyImmutable)
+                      case Immutable => NoOutcome
+                    })
                 case None => /* Do nothing */
               }
             }
@@ -280,11 +279,10 @@ object ImmutabilityAnalysis extends DefaultOneStepAnalysis {
         cellCompleter.cell.whenNext(
           classFileToObjectTypeCellCompleter(superClass)._1.cell,
           (imm: Immutability) => imm match {
-            case Immutable => FalsePred
-            case Mutable => WhenNextComplete
-            case ConditionallyImmutable => WhenNext
-          },
-          Some(_))
+            case Immutable => NoOutcome
+            case Mutable => FinalOutcome(Mutable)
+            case ConditionallyImmutable => NextOutcome(ConditionallyImmutable)
+          })
       }
     }
   }
@@ -312,12 +310,11 @@ object ImmutabilityAnalysis extends DefaultOneStepAnalysis {
       if (cf.isFinal || directSubtypes.isEmpty) {
         cellCompleter.cell.whenNext(
           classFileToObjectTypeCellCompleter(cf)._1.cell,
-          (imm: Immutability) => imm match {
-            case Immutable => FalsePred
-            case Mutable => WhenNextComplete
-            case ConditionallyImmutable => WhenNext
-          },
-          Some(_))
+          _ match {
+            case Immutable => NoOutcome
+            case Mutable => FinalOutcome(Mutable)
+            case ConditionallyImmutable => NextOutcome(ConditionallyImmutable)
+          })
       } else {
         val unavailableSubtype = directSubtypes.find(t ⇒ project.classFile(t).isEmpty)
         if (unavailableSubtype.isDefined)
@@ -329,12 +326,11 @@ object ImmutabilityAnalysis extends DefaultOneStepAnalysis {
           directSubclasses foreach { subclass =>
             cellCompleter.cell.whenNext(
               classFileToObjectTypeCellCompleter(subclass)._2.cell,
-              (imm: Immutability) => imm match {
-                case Immutable => FalsePred
-                case Mutable => WhenNextComplete
-                case ConditionallyImmutable => WhenNext
-              },
-              Some(_))
+              _ match {
+                case Immutable => NoOutcome
+                case Mutable => FinalOutcome(Mutable)
+                case ConditionallyImmutable => NextOutcome(ConditionallyImmutable)
+              })
           }
         }
       }

--- a/core/src/main/scala/opal/PurityAnalysis.scala
+++ b/core/src/main/scala/opal/PurityAnalysis.scala
@@ -3,14 +3,12 @@ package opal
 import java.net.URL
 
 import scala.collection.JavaConverters._
-
 import scala.concurrent.Await
 import scala.concurrent.duration._
-
-import cell.{ HandlerPool, CellCompleter, Cell }
+import cell._
 import org.opalj.Success
-import org.opalj.br.{ ClassFile, PC, Method, MethodWithBody }
-import org.opalj.br.analyses.{ BasicReport, DefaultOneStepAnalysis, Project }
+import org.opalj.br.{ClassFile, Method, MethodWithBody, PC}
+import org.opalj.br.analyses.{BasicReport, DefaultOneStepAnalysis, Project}
 import org.opalj.br.instructions.GETFIELD
 import org.opalj.br.instructions.GETSTATIC
 import org.opalj.br.instructions.PUTFIELD
@@ -164,7 +162,7 @@ object PurityAnalysis extends DefaultOneStepAnalysis {
 
                 val targetCellCompleter = methodToCellCompleter(callee)
                 hasDependencies = true
-                cellCompleter.cell.whenComplete(targetCellCompleter.cell, (p: Purity) => p == Impure, Impure)
+                cellCompleter.cell.whenComplete(targetCellCompleter.cell, p => if (p == Impure) FinalOutcome(Impure) else NoOutcome)
 
               case _ /* Empty or Failure */ ⇒
 

--- a/core/src/test/scala/internalBase.scala
+++ b/core/src/test/scala/internalBase.scala
@@ -24,8 +24,8 @@ class InternalBaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "key2")
     val cell1 = completer1.cell
     val cell2 = completer2.cell
-    cell1.whenComplete(cell2, (x: Int) => x == 0, 0)
-    cell1.whenComplete(cell2, (x: Int) => x == 0, 0)
+    cell1.whenComplete(cell2, x => if (x == 0) FinalOutcome(0) else NoOutcome)
+    cell1.whenComplete(cell2, x => if (x == 0) FinalOutcome(0) else NoOutcome)
 
     assert(cell1.numCompleteDependencies == 2)
     assert(cell2.numCompleteDependencies == 0)
@@ -37,8 +37,8 @@ class InternalBaseSuite extends FunSuite {
     val completer2 = CellCompleter[StringIntKey, Int](pool, "key2")
     val cell1 = completer1.cell
     val cell2 = completer2.cell
-    cell1.whenComplete(cell2, (x: Int) => x == 0, 0)
-    cell1.whenComplete(cell2, (x: Int) => x == 0, 0)
+    cell1.whenComplete(cell2,  x => if (x == 0) FinalOutcome(0) else NoOutcome)
+    cell1.whenComplete(cell2,  x => if (x == 0) FinalOutcome(0) else NoOutcome)
 
     completer1.putFinal(0)
 


### PR DESCRIPTION
This PR removes the second parameter of whenNext and whenComplete. Instead, the valueCallback for these methods returns an `Outcome` to indicate whether the returned value is final.

Tests have been adapted.