### PR TITLE
Remove whenComlpete-Callbacks before resolving via key.

### DIFF
--- a/core/src/main/scala/cell/HandlerPool.scala
+++ b/core/src/main/scala/cell/HandlerPool.scala
@@ -228,9 +228,7 @@ class HandlerPool(parallelism: Int = 8, unhandledExceptionHandler: Throwable => 
 
     for ((c, v) <- result) {
       cells.foreach(cell => {
-        // Note that there is a better solution for this in https://github.com/phaller/reactive-async/pull/58
-        c.removeNextCallbacks(cell)
-        c.removeCompleteCallbacks(cell)
+        c.removeAllCallbacks(cell)
       })
       c.resolveWithValue(v)
     }
@@ -245,9 +243,7 @@ class HandlerPool(parallelism: Int = 8, unhandledExceptionHandler: Throwable => 
 
     for ((c, v) <- result) {
       cells.foreach(cell => {
-        // Note that there is a better solution for this in https://github.com/phaller/reactive-async/pull/58
-        c.removeNextCallbacks(cell)
-        c.removeCompleteCallbacks(cell)
+        c.removeAllCallbacks(cell)
       })
       c.resolveWithValue(v)
     }

--- a/core/src/test/scala/cell/PsSuite.scala
+++ b/core/src/test/scala/cell/PsSuite.scala
@@ -53,7 +53,6 @@ class PsSuite extends FunSuite {
 
     completer20.putNext(1)
     cell20.whenNextSequential(cell10, x => {
-      println("other0")
       if (x == 10) {
         completer20.putFinal(43)
       }
@@ -63,7 +62,6 @@ class PsSuite extends FunSuite {
     completer1.putNext(10)
 
     cell1.whenNext(cell1, _ => {
-      println("itself")
       NoOutcome
     })
 
@@ -82,7 +80,6 @@ class PsSuite extends FunSuite {
     }
 
     override def fallback[K <: Key[Int]](cells: Seq[Cell[K, Int]]): Seq[(Cell[K, Int], Int)] = {
-      println("fallback")
       cells.map(cell ⇒ (cell, cell.getResult()))
     }
 


### PR DESCRIPTION
When resolving cycles, whenComplete callbacks should not be triggered among the cells that form the cycle. This is now handled by removing all deps between the cells involved. (Note that #47 mistakenly only removes whenNext dependencies.)

A test has been added.