### PR TITLE
Call whenNext callback with best value available.

### DIFF
--- a/core/src/main/scala/cell/Cell.scala
+++ b/core/src/main/scala/cell/Cell.scala
@@ -681,7 +681,7 @@ private class NextDepRunnable[K <: Key[V], V](
   override def apply(x: Try[V]): Unit = {
     x match {
       case Success(v) =>
-        shortCutValueCallback(v) match {
+        shortCutValueCallback(cell.getResult()) match {
           case NextOutcome(v) =>
             completer.putNext(v)
           case FinalOutcome(v) =>


### PR DESCRIPTION
`whenNext` callbacks retrieve the newest value of `other`, independently of which value that triggered the dependency.