### PR TITLE
Lazy computation

### DIFF
--- a/bench/src/test/scala/benchmark/rabenchmarks.scala
+++ b/bench/src/test/scala/benchmark/rabenchmarks.scala
@@ -1,4 +1,5 @@
-import cell.{ CellCompleter, HandlerPool }
+package cell
+
 import lattice.{ Lattice, NaturalNumberLattice, NaturalNumberKey }
 
 import scala.annotation.tailrec

--- a/core/src/main/scala/cell/CellCompleter.scala
+++ b/core/src/main/scala/cell/CellCompleter.scala
@@ -14,6 +14,8 @@ trait CellCompleter[K <: Key[V], V] {
    */
   def cell: Cell[K, V]
 
+  private[cell] def init: (Cell[K, V]) => Outcome[V]
+
   def putFinal(x: V): Unit
   def putNext(x: V): Unit
   def put(x: V, isFinal: Boolean): Unit
@@ -31,8 +33,8 @@ object CellCompleter {
    * Create a completer for a cell holding values of type `V`
    * given a `HandlerPool` and a `Key[V]`.
    */
-  def apply[K <: Key[V], V](key: K)(implicit lattice: Lattice[V], pool: HandlerPool): CellCompleter[K, V] = {
-    val impl = new CellImpl[K, V](pool, key, lattice)
+  def apply[K <: Key[V], V](key: K, init: (Cell[K, V]) => Outcome[V] = (_: Cell[K, V]) => NoOutcome)(implicit lattice: Lattice[V], pool: HandlerPool): CellCompleter[K, V] = {
+    val impl = new CellImpl[K, V](pool, key, lattice, init)
     pool.register(impl)
     impl
   }
@@ -44,7 +46,7 @@ object CellCompleter {
    * `DefaultKey[V]`, no other key would make sense.
    */
   def completed[V](result: V)(implicit lattice: Lattice[V], pool: HandlerPool): CellCompleter[DefaultKey[V], V] = {
-    val impl = new CellImpl[DefaultKey[V], V](pool, new DefaultKey[V], lattice)
+    val impl = new CellImpl[DefaultKey[V], V](pool, new DefaultKey[V], lattice, _ => NoOutcome)
     pool.register(impl)
     impl.putFinal(result)
     impl

--- a/core/src/test/scala/cell/LazySuite.scala
+++ b/core/src/test/scala/cell/LazySuite.scala
@@ -1,0 +1,304 @@
+package cell
+
+import java.util.concurrent.CountDownLatch
+
+import lattice.{ DefaultKey, Lattice, StringIntKey, StringIntLattice }
+import org.scalatest.FunSuite
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class LazySuite extends FunSuite {
+
+  implicit val stringIntLattice: Lattice[Int] = new StringIntLattice
+
+  test("lazy init") {
+    val latch = new CountDownLatch(1)
+    val pool = new HandlerPool()
+    val cell = pool.mkCell[StringIntKey, Int]("cell", _ => {
+      FinalOutcome(1)
+    })
+    cell.onComplete(_ => latch.countDown())
+
+    assert(!cell.isComplete)
+    cell.trigger()
+
+    latch.await()
+
+    assert(cell.isComplete)
+    assert(cell.getResult() == 1)
+
+    pool.shutdown()
+  }
+
+  test("trigger dependees") {
+    val latch = new CountDownLatch(2)
+    val pool = new HandlerPool()
+
+    var cell1: Cell[StringIntKey, Int] = null
+    var cell2: Cell[StringIntKey, Int] = null
+
+    cell1 = pool.mkCell[StringIntKey, Int]("cell1", _ => {
+      FinalOutcome(1)
+    })
+
+    cell2 = pool.mkCell[StringIntKey, Int]("cell2", _ => {
+      cell2.whenComplete(cell1, _ => {
+        FinalOutcome(3)
+      })
+      NextOutcome(2)
+    })
+
+    cell1.onComplete(_ => latch.countDown())
+    cell2.onComplete(_ => latch.countDown())
+
+    assert(!cell1.isComplete)
+    assert(!cell2.isComplete)
+    cell2.trigger()
+
+    latch.await()
+
+    assert(cell1.isComplete)
+    assert(cell1.getResult() == 1)
+
+    assert(cell2.isComplete)
+    assert(cell2.getResult() == 3)
+
+    pool.shutdown()
+  }
+
+  test("do not trigger unneeded cells") {
+    val latch = new CountDownLatch(1)
+    val pool = new HandlerPool()
+
+    var cell1: Cell[StringIntKey, Int] = null
+    var cell2: Cell[StringIntKey, Int] = null
+
+    cell1 = pool.mkCell[StringIntKey, Int]("cell1", _ => {
+      assert(false)
+      FinalOutcome(-11)
+    })
+
+    cell2 = pool.mkCell[StringIntKey, Int]("cell2", _ => {
+      FinalOutcome(2)
+    })
+
+    cell2.onComplete(_ => latch.countDown())
+
+    cell2.trigger()
+
+    latch.await()
+
+    assert(!cell1.isComplete)
+    assert(cell1.getResult() == 0)
+
+    pool.shutdown()
+  }
+
+  test("cycle deps") {
+    val latch1 = new CountDownLatch(2)
+    val latch2 = new CountDownLatch(2)
+    val pool = new HandlerPool()
+
+    var cell1: Cell[StringIntKey, Int] = null
+    var cell2: Cell[StringIntKey, Int] = null
+
+    cell1 = pool.mkCell[StringIntKey, Int]("cell1", _ => {
+      cell1.whenComplete(cell2, _ => {
+        FinalOutcome(3)
+      })
+      NextOutcome(1)
+    })
+
+    cell2 = pool.mkCell[StringIntKey, Int]("cell2", _ => {
+      cell2.whenComplete(cell1, _ => {
+        FinalOutcome(3)
+      })
+      NextOutcome(2)
+    })
+
+    cell1.onNext(_ => latch1.countDown())
+    cell2.onNext(_ => latch1.countDown())
+
+    cell1.onComplete(_ => latch2.countDown())
+    cell2.onComplete(_ => latch2.countDown())
+
+    cell2.trigger()
+    latch1.await()
+
+    pool.whileQuiescentResolveCell
+    val fut = pool.quiescentResolveCycles
+    val ready = Await.ready(fut, 2.seconds)
+
+    latch2.await()
+
+    assert(cell1.isComplete)
+    assert(cell1.getResult() == 0)
+
+    assert(cell2.isComplete)
+    assert(cell2.getResult() == 0)
+
+    pool.shutdown()
+  }
+
+  test("cycle deps with outgoing dep") {
+    val theKey = new DefaultKey[Int]()
+
+    val latch1 = new CountDownLatch(2)
+    val latch2 = new CountDownLatch(3)
+    val pool = new HandlerPool()
+
+    var cell1: Cell[theKey.type, Int] = null
+    var cell2: Cell[theKey.type, Int] = null
+    var cell3: Cell[theKey.type, Int] = null
+
+    cell1 = pool.mkCell[theKey.type, Int](theKey, _ => {
+      cell1.whenComplete(cell2, _ => NextOutcome(-1))
+      NextOutcome(101)
+    })
+
+    cell2 = pool.mkCell[theKey.type, Int](theKey, _ => {
+      cell2.whenComplete(cell1, _ => NextOutcome(-1))
+      NextOutcome(102)
+    })
+
+    cell3 = pool.mkCell[theKey.type, Int](theKey, _ => {
+      cell3.whenComplete(cell1, _ => FinalOutcome(103))
+      NextOutcome(-1)
+    })
+
+    cell1.onNext(_ => latch1.countDown())
+    cell2.onNext(_ => latch1.countDown())
+
+    cell1.onComplete(_ => latch2.countDown())
+    cell2.onComplete(_ => latch2.countDown())
+    cell3.onComplete(_ => latch2.countDown())
+
+    assert(!cell1.isComplete)
+    assert(!cell2.isComplete)
+
+    cell3.trigger()
+    latch1.await()
+
+    val fut = pool.quiescentResolveCycles
+    val ready = Await.ready(fut, 2.seconds)
+
+    latch2.await()
+
+    assert(cell3.isComplete)
+    assert(cell3.getResult() === 103)
+
+    pool.shutdown()
+  }
+
+  test("cycle deps with outgoing dep, resolve cycle first") {
+    val theKey = new DefaultKey[Int]()
+
+    val latch1 = new CountDownLatch(2)
+    val latch2 = new CountDownLatch(2)
+    val latch3 = new CountDownLatch(1)
+    val pool = new HandlerPool()
+
+    var cell1: Cell[theKey.type, Int] = null
+    var cell2: Cell[theKey.type, Int] = null
+    var cell3: Cell[theKey.type, Int] = null
+
+    cell1 = pool.mkCell[theKey.type, Int](theKey, _ => {
+      cell1.whenComplete(cell2, _ => {
+        NextOutcome(-111)
+      })
+      NextOutcome(11)
+    })
+
+    cell2 = pool.mkCell[theKey.type, Int](theKey, _ => {
+      cell2.whenComplete(cell1, _ => {
+        NextOutcome(-222)
+      })
+      NextOutcome(22)
+    })
+
+    cell1.onNext(_ => latch1.countDown())
+    cell2.onNext(_ => latch1.countDown())
+
+    cell1.onComplete(_ => latch2.countDown())
+    cell2.onComplete(_ => latch2.countDown())
+
+    cell2.trigger()
+    latch1.await()
+
+    val fut = pool.quiescentResolveCycles
+    val ready = Await.ready(fut, 2.seconds)
+
+    latch2.await()
+
+    cell3 = pool.mkCell[theKey.type, Int](theKey, _ => {
+      cell3.whenComplete(cell1, _ => {
+        FinalOutcome(333)
+      })
+      NextOutcome(-3)
+    })
+
+    cell3.onComplete(_ => latch3.countDown())
+    cell3.trigger()
+
+    latch3.await()
+
+    assert(cell3.isComplete)
+    assert(cell3.getResult() === 333)
+
+    pool.shutdown()
+  }
+
+  test("cycle does not get resolved, if not triggered") {
+    val pool = new HandlerPool()
+    var c1: Cell[StringIntKey, Int] = null
+    var c2: Cell[StringIntKey, Int] = null
+    c1 = pool.mkCell[StringIntKey, Int]("cell1", _ => {
+      c1.whenNext(c2, _ => FinalOutcome(-2))
+      FinalOutcome(-1)
+    })
+    c2 = pool.mkCell[StringIntKey, Int]("cell2", _ => {
+      c2.whenNext(c1, _ => FinalOutcome(-2))
+      FinalOutcome(-1)
+    })
+
+    val fut2 = pool.quiescentResolveCell
+    Await.ready(fut2, 2.seconds)
+
+    assert(c1.getResult() == 0)
+    assert(!c1.isComplete)
+    assert(c2.getResult() == 0)
+    assert(!c2.isComplete)
+
+    pool.shutdown()
+  }
+
+  test("cell does not get resolved, if not triggered") {
+    val pool = new HandlerPool()
+    val c = pool.mkCell[StringIntKey, Int]("cell1", _ => FinalOutcome(-1))
+
+    val fut2 = pool.quiescentResolveCell
+    Await.ready(fut2, 2.seconds)
+
+    assert(c.getResult() == 0)
+    assert(!c.isComplete)
+
+    pool.shutdown()
+  }
+
+  test("cell gets resolved, if triggered") {
+    val pool = new HandlerPool()
+    val cell = pool.mkCell[StringIntKey, Int]("cell1", _ => {
+      NextOutcome(-1)
+    })
+    cell.trigger()
+
+    val fut2 = pool.quiescentResolveCell
+    Await.ready(fut2, 2.seconds)
+
+    assert(cell.isComplete) // cell should be completed with a fallback value
+    assert(cell.getResult() == 1) // StringIntKey sets cell to fallback value `1`.
+
+    pool.shutdown()
+  }
+}

--- a/core/src/test/scala/pool.scala
+++ b/core/src/test/scala/pool.scala
@@ -1,10 +1,11 @@
+package cell
+
 import java.util.concurrent.ConcurrentHashMap
 
 import org.scalatest.FunSuite
 
 import scala.concurrent.{ Await, Promise }
 import scala.concurrent.duration._
-import cell.{ Cell, CellCompleter, HandlerPool }
 import lattice.{ Lattice, StringIntKey, StringIntLattice }
 
 class PoolSuite extends FunSuite {
@@ -37,6 +38,7 @@ class PoolSuite extends FunSuite {
     for (_ <- 1 to 1000) {
       pool.execute(() => {
         val completer = CellCompleter[StringIntKey, Int]("somekey")
+        completer.cell.trigger()
         regCells.put(completer.cell, completer.cell)
         ()
       })
@@ -47,5 +49,24 @@ class PoolSuite extends FunSuite {
     regCells.values().removeIf(_.getResult() != 0)
     assert(regCells.size === 0)
   }
+
+  test("register cells concurrently 2") {
+    implicit val stringIntLattice: Lattice[Int] = new StringIntLattice
+
+    implicit val pool = new HandlerPool()
+    var regCells = new ConcurrentHashMap[Cell[StringIntKey, Int], Cell[StringIntKey, Int]]()
+    for (_ <- 1 to 1000) {
+      pool.execute(() => {
+        val completer = CellCompleter[StringIntKey, Int]("somekey")
+        regCells.put(completer.cell, completer.cell)
+        ()
+      })
+    }
+    val fut = pool.quiescentResolveDefaults // set all (registered) cells to 1 via key.fallback
+    Await.ready(fut, 5.seconds)
+
+    assert(regCells.size === 1000)
+  }
+
 
 }


### PR DESCRIPTION
- `init` callbacks are attached to each cell.
- Those get called as soon a cell becomes interesting (gets triggered explicitly or implicitly via a dependency).
- `init`s build up dependencies and return an (initial) `Outcome` for the cell.

Tests have been adapted/added.

Note:
- ImmutabilityAnalysis has been removed. It has not been used anywhere. If you are OK with the general direction of this PR, I am going to adapt it.
- This includes a quick fix of what is handled properly by #58 .