### PR TITLE
Register whenComplete dependency correctly

### DIFF
--- a/core/src/main/scala/cell/Cell.scala
+++ b/core/src/main/scala/cell/Cell.scala
@@ -330,22 +330,27 @@ private class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: L
    *  is completed (either prior or after an invocation of `whenComplete`).
    */
   override def whenComplete(other: Cell[K, V], valueCallback: V => Outcome[V]): Unit = {
-    state.get() match {
-      case finalRes: Try[_] => // completed with final result
-      // do not add dependency
-      // in fact, do nothing
+    var success = false
+    while (!success) {
+      state.get() match {
+        case finalRes: Try[_] => // completed with final result
+        // do not add dependency
+        // in fact, do nothing
 
-      case raw: State[_, _] => // not completed
-        val newDep = new CompleteDepRunnable(pool, other, valueCallback, this)
-        // TODO: it looks like `newDep` is wrapped into a CallbackRunnable by `onComplete` -> bad
-        other.addCallback(newDep, this)
+        case raw: State[_, _] => // not completed
+          val newDep = new CompleteDepRunnable(pool, other, valueCallback, this)
+          // TODO: it looks like `newDep` is wrapped into a CallbackRunnable by `onComplete` -> bad
 
-        val current = raw.asInstanceOf[State[K, V]]
-        val newState = current.deps.contains(other) match {
-          case true => new State(current.res, current.deps + (other -> (newDep :: current.deps(other))), current.callbacks, current.nextDeps, current.nextCallbacks)
-          case false => new State(current.res, current.deps + (other -> List(newDep)), current.callbacks, current.nextDeps, current.nextCallbacks)
-        }
-        state.compareAndSet(current, newState)
+          val current = raw.asInstanceOf[State[K, V]]
+          val newState = current.deps.contains(other) match {
+            case true => new State(current.res, current.deps + (other -> (newDep :: current.deps(other))), current.callbacks, current.nextDeps, current.nextCallbacks)
+            case false => new State(current.res, current.deps + (other -> List(newDep)), current.callbacks, current.nextDeps, current.nextCallbacks)
+          }
+          if (state.compareAndSet(current, newState)) {
+            success = true
+            other.addCallback(newDep, this)
+          }
+      }
     }
   }
 


### PR DESCRIPTION
This change has been copied from whenNext, where this is handled well.