### PR TITLE
Ensure that a cell is registered via CAS.

### DIFF
--- a/core/src/main/scala/cell/HandlerPool.scala
+++ b/core/src/main/scala/cell/HandlerPool.scala
@@ -43,9 +43,12 @@ class HandlerPool(parallelism: Int = 8, unhandledExceptionHandler: Throwable => 
   }
 
   def register[K <: Key[V], V](cell: Cell[K, V]): Unit = {
-    val registered = cellsNotDone.get()
-    val newRegistered = registered + (cell -> cell)
-    cellsNotDone.compareAndSet(registered, newRegistered)
+    var success = false
+    while (!success) {
+      val registered = cellsNotDone.get()
+      val newRegistered = registered + (cell -> cell)
+      success = cellsNotDone.compareAndSet(registered, newRegistered)
+    }
   }
 
   def deregister[K <: Key[V], V](cell: Cell[K, V]): Unit = {

--- a/core/src/test/scala/cell/base.scala
+++ b/core/src/test/scala/cell/base.scala
@@ -1,12 +1,12 @@
 package cell
 
 import org.scalatest.FunSuite
-import java.util.concurrent.CountDownLatch
+import java.util.concurrent.{ ConcurrentHashMap, CountDownLatch }
 
 import scala.util.{ Failure, Success }
 import scala.concurrent.{ Await, Promise }
 import scala.concurrent.duration._
-import lattice.{ Lattice, StringIntLattice, StringIntKey, LatticeViolationException, DefaultKey, Key }
+import lattice.{ DefaultKey, Key, Lattice, LatticeViolationException, StringIntKey, StringIntLattice }
 import opal._
 import org.opalj.br.analyses.Project
 import java.io.File


### PR DESCRIPTION
Use the same loop that has already been used in `deregister` to ensure that a dependency is registered, even if `register` is called concurrently.
This is only needed, if `register` could be called in such a way. Maybe, after applying #60 one could ensure that this does not happen, but as is, `register` is public, so there are no guarantees.