### PR TITLE
Add `when` dependency that is triggered for `next` and `final` updates.

### DIFF
--- a/core/src/test/scala/cell/base.scala
+++ b/core/src/test/scala/cell/base.scala
@@ -549,6 +549,51 @@ class BaseSuite extends FunSuite {
     pool.shutdown()
   }
 
+  test("when: values passed to callback") {
+    val latch1 = new CountDownLatch(1)
+    val latch2 = new CountDownLatch(1)
+
+    val pool = new HandlerPool
+    val completer1 = CellCompleter[StringIntKey, Int](pool, "somekey")
+    val completer2 = CellCompleter[StringIntKey, Int](pool, "someotherkey")
+
+    val cell1 = completer1.cell
+    cell1.when(completer2.cell, (x, isFinal) => {
+      Outcome(x, isFinal) // complete, if completer2 is completed
+    })
+
+    cell1.onNext {
+      case Success(x) =>
+        assert(x === 8)
+        assert(!cell1.isComplete)
+        latch1.countDown()
+      case Failure(e) =>
+        assert(false)
+        latch1.countDown()
+    }
+
+    cell1.onComplete {
+      case Success(x) =>
+        assert(x === 10)
+        latch2.countDown()
+      case Failure(e) =>
+        assert(false)
+        latch2.countDown()
+    }
+
+    completer1.putNext(8)
+    latch1.await()
+
+    assert(!cell1.isComplete)
+
+    completer2.putFinal(10)
+    latch2.await()
+
+    assert(cell1.isComplete)
+
+    pool.shutdown()
+  }
+
   test("put: isFinal == true") {
     val latch = new CountDownLatch(1)
 


### PR DESCRIPTION
Note that this changes, how dependencies/callbacsk are counted: The new `when` counts for both nextDeps and completeDeps. Currently, those are only needed for tests.