### PR TITLE
Let Lattice extend PartialOrdering

### DIFF
--- a/core/src/main/scala/lattice/Lattice.scala
+++ b/core/src/main/scala/lattice/Lattice.scala
@@ -3,12 +3,37 @@ package lattice
 import scala.annotation.implicitNotFound
 
 @implicitNotFound("type ${V} does not have a Lattice instance")
-trait Lattice[V] {
+trait Lattice[V] extends PartialOrdering[V] {
   /**
    * Return Some(v) if a new value v was computed (v != current), else None.
    * If it fails, throw exception.
    */
   def join(current: V, next: V): V
+
+  def lteq(v1: V, v2: V): Boolean = {
+    try
+      join(v1, v2) == v2
+    catch { case _: LatticeViolationException[V] => false }
+  }
+
+  override def gteq(v1: V, v2: V): Boolean = {
+    try
+      join(v1, v2) == v1
+    catch { case _: LatticeViolationException[V] => false }
+  }
+
+  /**
+   * Result of comparing x with operand y. Returns None if operands are not comparable. If operands are comparable, returns Some(r) where
+   * r < 0 iff x < y
+   * r == 0 iff x == y
+   * r > 0 iff x > y
+   */
+  override def tryCompare(x: V, y: V): Option[Int] =
+    if (lt(x, y)) Some(-1)
+    else if (gt(x, y)) Some(1)
+    else if (x == y) Some(0)
+    else None
+
   def empty: V
 }
 
@@ -20,6 +45,10 @@ object Lattice {
         (lattice.join(current._1, next._1), lattice.join(current._2, next._2))
       def empty: (T, T) =
         (lattice.empty, lattice.empty)
+      override def lteq(v1: (T, T), v2: (T, T)): Boolean =
+        lattice.lteq(v1._1, v2._1) && lattice.lteq(v1._2, v2._2)
+      override def gteq(v1: (T, T), v2: (T, T)): Boolean =
+        lattice.gteq(v1._1, v2._1) && lattice.gteq(v1._2, v2._2)
     }
   }
 
@@ -30,6 +59,10 @@ object Lattice {
         if (current == null) next
         else throw LatticeViolationException(current, next)
       }
+      override def lteq(v1: T, v2: T): Boolean =
+        (v1 == empty) || (v1 == v2)
+      override def gteq(v1: T, v2: T): Boolean =
+        (v2 == empty) || (v1 == v2)
     }
   }
 

--- a/core/src/main/scala/lattice/Lattices/NaturalNumberLattice.scala
+++ b/core/src/main/scala/lattice/Lattices/NaturalNumberLattice.scala
@@ -8,5 +8,11 @@ class NaturalNumberLattice extends Lattice[Int] {
     else current
   }
 
+  override def lteq(v1: Int, v2: Int): Boolean = v1 <= v2
+  override def gteq(v1: Int, v2: Int): Boolean = v1 >= v2
+  override def lt(v1: Int, v2: Int): Boolean = v1 < v2
+  override def gt(v1: Int, v2: Int): Boolean = v1 > v2
+  override def tryCompare(x: Int, y: Int): Option[Int] = Some(x - y)
+
   override def empty: Int = 0
 }

--- a/core/src/test/scala/LatticeSuite.scala
+++ b/core/src/test/scala/LatticeSuite.scala
@@ -1,0 +1,125 @@
+import lattice.{Lattice, LatticeViolationException, NaturalNumberLattice}
+import opal._
+import opal.Immutability.ImmutabilityLattice
+import opal.Purity.PurityLattice
+import org.scalatest.FunSuite
+
+class LatticeSuite extends FunSuite {
+  test("lteq 1") {
+    val l = new NaturalNumberLattice
+    assert(l.lteq(1, 2))
+  }
+
+  test("lteq 2") {
+    val l = new NaturalNumberLattice
+    assert(l.lteq(2, 2))
+  }
+
+  test("lt 1") {
+    val l = new NaturalNumberLattice
+    assert(l.lt(1, 2))
+  }
+
+  test("lt 2") {
+    val l = new NaturalNumberLattice
+    assert(!l.lt(2, 1))
+  }
+
+  test("gteq 1") {
+    val l = new NaturalNumberLattice
+    assert(l.gteq(3, 2))
+  }
+
+  test("gteq 2") {
+    val l = new NaturalNumberLattice
+    assert(l.gteq(2, 2))
+  }
+
+  test("gt 1") {
+    val l = new NaturalNumberLattice
+    assert(!l.gt(1, 2))
+  }
+
+  test("gt 2") {
+    val l = new NaturalNumberLattice
+    assert(l.gt(2, 1))
+  }
+
+  test("tryCompare 1") {
+    val l = new NaturalNumberLattice
+    assert(l.tryCompare(1, 2).get < 0)
+  }
+
+  test("tryCompare 2") {
+    val l = new NaturalNumberLattice
+    assert(l.tryCompare(2, 2).get == 0)
+  }
+
+  test("tryCompare 3") {
+    val l = new NaturalNumberLattice
+    assert(l.tryCompare(2, 1).get > 0)
+  }
+
+  test("join") {
+    val l = new NaturalNumberLattice
+    assert(l.join(1, 2) == 2)
+  }
+
+  test("trivial 1") {
+    object A
+    object B
+    val l = Lattice.trivial[AnyRef]
+    assert(l.lt(null, A))
+    assert(l.lteq(null, A))
+    assert(!l.gt(null, A))
+    assert(!l.gteq(null, A))
+    assert(l.tryCompare(A, A).get == 0)
+    assert(l.tryCompare(A, null).get > 0)
+    assert(l.tryCompare(null, A).get < 0)
+
+    assert(!l.lt(A, B))
+    assert(!l.lteq(A, B))
+    assert(!l.gt(A, B))
+    assert(!l.gteq(A, B))
+    assert(l.tryCompare(A, B).isEmpty)
+  }
+
+  test("trivial: join 1") {
+    object A
+    object B
+    val l = Lattice.trivial[AnyRef]
+    var top = false
+    try
+      l.join(A, B)
+    catch {
+      case _: LatticeViolationException[_] => top = true
+    }
+    assert(top)
+  }
+
+  test("trivial: join 2") {
+    object A
+    object B
+    val l = Lattice.trivial[AnyRef]
+    assert(l.join(null, A) === A)
+  }
+
+  test("client defined lattice 1") {
+    val l = PurityLattice
+    val A = Pure
+    val B = Impure
+
+    assert(l.lt(l.empty, A))
+    assert(l.lteq(l.empty, A))
+    assert(!l.gt(l.empty, A))
+    assert(!l.gteq(l.empty, A))
+    assert(l.tryCompare(A, A).get == 0)
+    assert(l.tryCompare(l.empty, A).get < 0)
+
+    assert(!l.lt(A, B))
+    assert(!l.lteq(A, B))
+    assert(!l.gt(A, B))
+    assert(!l.gteq(A, B))
+    assert(l.tryCompare(A, B).isEmpty)
+  }
+}


### PR DESCRIPTION
Add default implementations for all inherited methods.
Add a bunch of tests for Lattice and some standard lattices.

Fixes #86