### PR TITLE
Call whenNext callback immediately after creation

### DIFF
--- a/core/src/main/scala/cell/Cell.scala
+++ b/core/src/main/scala/cell/Cell.scala
@@ -625,6 +625,7 @@ private class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: L
           case false => new State(current.res, current.completeDeps, current.completeCallbacks, current.nextDeps, current.nextCallbacks + (runnable.dependentCell -> List(runnable)))
         }
         if (!state.compareAndSet(pre, newState)) dispatchOrAddNextCallback(runnable)
+        else if (current.res != lattice.empty) runnable.execute()
     }
   }
 


### PR DESCRIPTION
Call whenNext callback immediately after creation, if value is not bottom.

A test has been added. Some tests had to be adapted.

This fixes #81 , but see gitter and the test for a discussion, why the signature has not been changed. (Instead, semantics of whenNext have been changed.)