### PR TITLE
Updater class

### DIFF
--- a/bench/src/test/scala/benchmark/rabenchmarks.scala
+++ b/bench/src/test/scala/benchmark/rabenchmarks.scala
@@ -2,8 +2,6 @@ package cell
 
 import lattice.{ Lattice, NaturalNumberLattice, NaturalNumberKey }
 
-import scala.annotation.tailrec
-
 import org.scalameter.api._
 import org.scalameter.picklers.noPickler._
 

--- a/core/src/main/scala/cell/CellCompleter.scala
+++ b/core/src/main/scala/cell/CellCompleter.scala
@@ -1,8 +1,7 @@
 package cell
 
 import scala.util.Try
-
-import lattice.{ Lattice, Key, DefaultKey }
+import lattice.{ DefaultKey, Key, Updater }
 
 /**
  * Interface trait for programmatically completing a cell. Analogous to `Promise[V]`.
@@ -33,8 +32,8 @@ object CellCompleter {
    * Create a completer for a cell holding values of type `V`
    * given a `HandlerPool` and a `Key[V]`.
    */
-  def apply[K <: Key[V], V](key: K, init: (Cell[K, V]) => Outcome[V] = (_: Cell[K, V]) => NoOutcome)(implicit lattice: Lattice[V], pool: HandlerPool): CellCompleter[K, V] = {
-    val impl = new CellImpl[K, V](pool, key, lattice, init)
+  def apply[K <: Key[V], V](key: K, init: (Cell[K, V]) => Outcome[V] = (_: Cell[K, V]) => NoOutcome)(implicit updater: Updater[V], pool: HandlerPool): CellCompleter[K, V] = {
+    val impl = new CellImpl[K, V](pool, key, updater, init)
     pool.register(impl)
     impl
   }
@@ -45,8 +44,8 @@ object CellCompleter {
    * Note: there is no `K` type parameter, since we always use type
    * `DefaultKey[V]`, no other key would make sense.
    */
-  def completed[V](result: V)(implicit lattice: Lattice[V], pool: HandlerPool): CellCompleter[DefaultKey[V], V] = {
-    val impl = new CellImpl[DefaultKey[V], V](pool, new DefaultKey[V], lattice, _ => NoOutcome)
+  def completed[V](result: V)(implicit updater: Updater[V], pool: HandlerPool): CellCompleter[DefaultKey[V], V] = {
+    val impl = new CellImpl[DefaultKey[V], V](pool, new DefaultKey[V], updater, _ => NoOutcome)
     pool.register(impl)
     impl.putFinal(result)
     impl

--- a/core/src/main/scala/cell/HandlerPool.scala
+++ b/core/src/main/scala/cell/HandlerPool.scala
@@ -7,7 +7,8 @@ import scala.annotation.tailrec
 import scala.util.control.NonFatal
 import scala.concurrent.{ Await, Future, Promise }
 import scala.concurrent.duration._
-import lattice.{ DefaultKey, Key, Lattice }
+
+import lattice.{ DefaultKey, Key, Updater }
 import org.opalj.graphs._
 
 import scala.collection.immutable.Queue
@@ -37,11 +38,11 @@ class HandlerPool(parallelism: Int = 8, unhandledExceptionHandler: Throwable => 
    *
    * @param key The key to resolve this cell if in a cycle or no result computed.
    * @param init A callback to return the initial value for this cell and to set up dependencies.
-   * @param lattice The lattice of which the values of this cell are taken from.
+   * @param updater The updater used to update the value of this cell.
    * @return Returns a cell.
    */
-  def mkCell[K <: Key[V], V](key: K, init: (Cell[K, V]) => Outcome[V])(implicit lattice: Lattice[V]): Cell[K, V] = {
-    CellCompleter(key, init)(lattice, this).cell
+  def mkCell[K <: Key[V], V](key: K, init: (Cell[K, V]) => Outcome[V])(implicit updater: Updater[V]): Cell[K, V] = {
+    CellCompleter(key, init)(updater, this).cell
   }
 
   /**
@@ -49,11 +50,11 @@ class HandlerPool(parallelism: Int = 8, unhandledExceptionHandler: Throwable => 
    *
    * Creates a new, completed cell with value `v`.
    *
-   * @param lattice The lattice from which the values of this cell are taken
+   * @param updater The updater used to update the value of this cell.
    * @return Returns a cell with value `v`.
    */
-  def mkCompletedCell[V](result: V)(implicit lattice: Lattice[V]): Cell[DefaultKey[V], V] = {
-    CellCompleter.completed(result)(lattice, this).cell
+  def mkCompletedCell[V](result: V)(implicit updater: Updater[V]): Cell[DefaultKey[V], V] = {
+    CellCompleter.completed(result)(updater, this).cell
   }
 
   @tailrec

--- a/core/src/main/scala/lattice/Lattice.scala
+++ b/core/src/main/scala/lattice/Lattice.scala
@@ -2,38 +2,59 @@ package lattice
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound("type ${V} does not have a Lattice instance")
-trait Lattice[V] {
+trait PartialOrderingWithBottom[V] extends PartialOrdering[V] {
   /**
-   * Return Some(v) if a new value v was computed (v != current), else None.
-   * If it fails, throw exception.
+   * Result of comparing x with operand y. Returns None if operands are not comparable. If operands are comparable, returns Some(r) where
+   * r < 0 iff x < y
+   * r == 0 iff x == y
+   * r > 0 iff x > y
    */
-  def join(current: V, next: V): V
-  def empty: V
+  override def tryCompare(x: V, y: V): Option[Int] =
+    if (lt(x, y)) Some(-1)
+    else if (gt(x, y)) Some(1)
+    else if (equiv(x, y)) Some(0)
+    else None
+
+  def bottom: V
+}
+
+object PartialOrderingWithBottom {
+  def trivial[T >: Null]: PartialOrderingWithBottom[T] = {
+    new PartialOrderingWithBottom[T] {
+      override def bottom: T = null
+      override def lteq(v1: T, v2: T): Boolean =
+        (v1 == bottom) || (v1 == v2)
+    }
+  }
+}
+
+@implicitNotFound("type ${V} does not have a Lattice instance")
+trait Lattice[V] extends PartialOrderingWithBottom[V] {
+  /**
+   * Return the join of v1 and v2 wrt. the lattice.
+   */
+  def join(v1: V, v2: V): V
+
+  def lteq(v1: V, v2: V): Boolean = {
+    join(v1, v2) == v2
+  }
+
+  override def gteq(v1: V, v2: V): Boolean = {
+    join(v1, v2) == v1
+  }
 }
 
 object Lattice {
-
   implicit def pair[T](implicit lattice: Lattice[T]): Lattice[(T, T)] = {
     new Lattice[(T, T)] {
-      def join(current: (T, T), next: (T, T)): (T, T) =
-        (lattice.join(current._1, next._1), lattice.join(current._2, next._2))
-      def empty: (T, T) =
-        (lattice.empty, lattice.empty)
+      def join(v1: (T, T), v2: (T, T)): (T, T) =
+        (lattice.join(v1._1, v2._1), lattice.join(v1._2, v2._2))
+      def bottom: (T, T) =
+        (lattice.bottom, lattice.bottom)
+      override def lteq(v1: (T, T), v2: (T, T)): Boolean =
+        lattice.lteq(v1._1, v2._1) && lattice.lteq(v1._2, v2._2)
+      override def gteq(v1: (T, T), v2: (T, T)): Boolean =
+        lattice.gteq(v1._1, v2._1) && lattice.gteq(v1._2, v2._2)
     }
   }
-
-  def trivial[T >: Null]: Lattice[T] = {
-    new Lattice[T] {
-      override def empty: T = null
-      override def join(current: T, next: T): T = {
-        if (current == null) next
-        else throw LatticeViolationException(current, next)
-      }
-    }
-  }
-
 }
-
-final case class LatticeViolationException[D](current: D, next: D) extends IllegalStateException(
-  s"Violation of lattice with current $current and next $next!")

--- a/core/src/main/scala/lattice/Lattices/NaturalNumberLattice.scala
+++ b/core/src/main/scala/lattice/Lattices/NaturalNumberLattice.scala
@@ -3,10 +3,16 @@ package lattice
 object NaturalNumberKey extends DefaultKey[Int]
 
 class NaturalNumberLattice extends Lattice[Int] {
-  override def join(current: Int, next: Int): Int = {
-    if (next > current) next
-    else current
+  override def join(v1: Int, v2: Int): Int = {
+    if (v2 > v1) v2
+    else v1
   }
 
-  override def empty: Int = 0
+  override def lteq(v1: Int, v2: Int): Boolean = v1 <= v2
+  override def gteq(v1: Int, v2: Int): Boolean = v1 >= v2
+  override def lt(v1: Int, v2: Int): Boolean = v1 < v2
+  override def gt(v1: Int, v2: Int): Boolean = v1 > v2
+  override def tryCompare(x: Int, y: Int): Option[Int] = Some(x - y)
+
+  override def bottom: Int = 0
 }

--- a/core/src/main/scala/lattice/Lattices/StringIntLattice.scala
+++ b/core/src/main/scala/lattice/Lattices/StringIntLattice.scala
@@ -21,11 +21,13 @@ object StringIntKey {
     new StringIntKey(s)
 }
 
-class StringIntLattice extends Lattice[Int] {
-  override def join(current: Int, next: Int): Int = {
-    if (current != next) next
-    else current
-  }
+class StringIntUpdater extends Updater[Int] with PartialOrderingWithBottom[Int] {
+  override def update(v1: Int, v2: Int): Int =
+    if (v1 != v2) v2
+    else v1
 
-  override def empty: Int = 0
+  override def bottom: Int = 0
+
+  override def lteq(x: Int, y: Int): Boolean = x <= y
 }
+

--- a/core/src/main/scala/lattice/updater.scala
+++ b/core/src/main/scala/lattice/updater.scala
@@ -1,0 +1,49 @@
+package lattice
+
+trait Updater[V] {
+  this: PartialOrderingWithBottom[V] =>
+
+  def bottom: V
+  def update(current: V, next: V): V
+}
+
+trait AggregationUpdater[V] extends Lattice[V] with Updater[V] {
+  override def update(current: V, next: V): V = join(current, next)
+}
+
+trait MonotonicUpdater[V] extends PartialOrderingWithBottom[V] with Updater[V] {
+  override def update(current: V, next: V): V =
+    if (lteq(current, next)) next
+    else throw new NotMonotonicException(current, next)
+}
+
+object Updater {
+  implicit def latticeToUpdater[T](implicit lattice: Lattice[T]): Updater[T] =
+    new AggregationUpdater[T] {
+      override def join(v1: T, v2: T): T = lattice.join(v1, v2)
+
+      override def bottom: T = lattice.bottom
+    }
+
+  def partialOrderingToUpdater[T](implicit partialOrderingWithBottom: PartialOrderingWithBottom[T]): Updater[T] =
+    new MonotonicUpdater[T] {
+      override def bottom: T = partialOrderingWithBottom.bottom
+      override def lteq(x: T, y: T): Boolean = partialOrderingWithBottom.lteq(x, y)
+    }
+
+  //  def pair[T](implicit lattice: Lattice[T]): Updater[(T, T)] = latticeToUpdater(Lattice.pair(lattice))
+
+  def pair[T](implicit updater: Updater[T]): Updater[(T, T)] = new Updater[(T, T)] with PartialOrderingWithBottom[(T, T)] {
+    override def update(current: (T, T), next: (T, T)): (T, T) =
+      (updater.update(current._1, next._1), updater.update(current._2, next._2))
+
+    override def bottom: (T, T) =
+      (updater.asInstanceOf[PartialOrderingWithBottom[T]].bottom, updater.asInstanceOf[PartialOrderingWithBottom[T]].bottom)
+
+    override def lteq(x: (T, T), y: (T, T)): Boolean =
+      updater.asInstanceOf[PartialOrderingWithBottom[T]].lteq(x._1, y._1) && updater.asInstanceOf[PartialOrderingWithBottom[T]].lteq(x._2, y._2)
+  }
+}
+
+final case class NotMonotonicException[D](current: D, next: D) extends IllegalStateException(
+  s"Violation of lattice with current $current and next $next!")

--- a/core/src/test/scala/LatticeSuite.scala
+++ b/core/src/test/scala/LatticeSuite.scala
@@ -1,0 +1,123 @@
+import lattice.{ Lattice, NaturalNumberLattice, PartialOrderingWithBottom }
+import org.scalatest.FunSuite
+
+class LatticeSuite extends FunSuite {
+  test("lteq 1") {
+    val l = new NaturalNumberLattice
+    assert(l.lteq(1, 2))
+  }
+
+  test("lteq 2") {
+    val l = new NaturalNumberLattice
+    assert(l.lteq(2, 2))
+  }
+
+  test("lt 1") {
+    val l = new NaturalNumberLattice
+    assert(l.lt(1, 2))
+  }
+
+  test("lt 2") {
+    val l = new NaturalNumberLattice
+    assert(!l.lt(2, 1))
+  }
+
+  test("gteq 1") {
+    val l = new NaturalNumberLattice
+    assert(l.gteq(3, 2))
+  }
+
+  test("gteq 2") {
+    val l = new NaturalNumberLattice
+    assert(l.gteq(2, 2))
+  }
+
+  test("gt 1") {
+    val l = new NaturalNumberLattice
+    assert(!l.gt(1, 2))
+  }
+
+  test("gt 2") {
+    val l = new NaturalNumberLattice
+    assert(l.gt(2, 1))
+  }
+
+  test("tryCompare 1") {
+    val l = new NaturalNumberLattice
+    assert(l.tryCompare(1, 2).get < 0)
+  }
+
+  test("tryCompare 2") {
+    val l = new NaturalNumberLattice
+    assert(l.tryCompare(2, 2).get == 0)
+  }
+
+  test("tryCompare 3") {
+    val l = new NaturalNumberLattice
+    assert(l.tryCompare(2, 1).get > 0)
+  }
+
+  test("join") {
+    val l = new NaturalNumberLattice
+    assert(l.join(1, 2) == 2)
+  }
+
+  test("trivial 1") {
+    object A
+    object B
+    val l = PartialOrderingWithBottom.trivial[AnyRef]
+    assert(l.lt(null, A))
+    assert(l.lteq(null, A))
+    assert(!l.gt(null, A))
+    assert(!l.gteq(null, A))
+    assert(l.tryCompare(A, A).get == 0)
+    assert(l.tryCompare(A, null).get > 0)
+    assert(l.tryCompare(null, A).get < 0)
+
+    assert(!l.lt(A, B))
+    assert(!l.lteq(A, B))
+    assert(!l.gt(A, B))
+    assert(!l.gteq(A, B))
+    assert(l.tryCompare(A, B).isEmpty)
+  }
+
+  test("client defined lattice 1") {
+    sealed trait Value
+    case object Bottom extends Value
+    case object A extends Value
+    case object B extends Value
+    case object Top extends Value
+
+    object L extends Lattice[Value] {
+      override def join(v1: Value, v2: Value): Value =
+        if (v1 == Bottom) v2
+        else if (v2 == Bottom) v1
+        else if (v1 == v2) v1
+        else Top
+
+      override val bottom: Value = Bottom
+    }
+
+    assert(L.lt(L.bottom, A))
+    assert(L.lteq(L.bottom, A))
+    assert(!L.gt(L.bottom, A))
+    assert(!L.gteq(L.bottom, A))
+    assert(L.tryCompare(A, A).get == 0)
+    assert(L.tryCompare(L.bottom, A).get < 0)
+
+    assert(!L.lt(A, B))
+    assert(!L.lteq(A, B))
+    assert(!L.gt(A, B))
+    assert(!L.gteq(A, B))
+    assert(L.tryCompare(A, B).isEmpty)
+
+    assert(L.join(A, B) == Top)
+    assert(L.join(Bottom, A) == A)
+    assert(L.join(B, Bottom) == B)
+    assert(L.join(A, Top) == Top)
+    assert(L.join(Top, B) == Top)
+    assert(L.join(Bottom, Top) == Top)
+    assert(L.join(Top, Bottom) == Top)
+    assert(L.join(A, A) == A)
+  }
+}

--- a/core/src/test/scala/cell/LazySuite.scala
+++ b/core/src/test/scala/cell/LazySuite.scala
@@ -2,7 +2,7 @@ package cell
 
 import java.util.concurrent.CountDownLatch
 
-import lattice.{ DefaultKey, Lattice, StringIntKey, StringIntLattice }
+import lattice.{ DefaultKey, Lattice, StringIntKey, StringIntUpdater, Updater }
 import org.scalatest.FunSuite
 
 import scala.concurrent.Await
@@ -10,7 +10,7 @@ import scala.concurrent.duration._
 
 class LazySuite extends FunSuite {
 
-  implicit val stringIntLattice: Lattice[Int] = new StringIntLattice
+  implicit val stringIntUpdater: Updater[Int] = new StringIntUpdater
 
   test("lazy init") {
     val latch = new CountDownLatch(1)

--- a/core/src/test/scala/internalBase.scala
+++ b/core/src/test/scala/internalBase.scala
@@ -16,7 +16,7 @@ import org.opalj.br.analyses.Project
 
 class InternalBaseSuite extends FunSuite {
 
-  implicit val stringIntLattice: Lattice[Int] = new StringIntLattice
+  implicit val stringIntUpdater: Updater[Int] = new StringIntUpdater
 
   test("cellDependencies: By adding dependencies") {
     implicit val pool = new HandlerPool

--- a/core/src/test/scala/latticetest/PowerSetLattice.scala
+++ b/core/src/test/scala/latticetest/PowerSetLattice.scala
@@ -3,7 +3,7 @@ package latticetest
 import org.scalatest.FunSuite
 
 import cell._
-import lattice.{ Lattice, LatticeViolationException, Key }
+import lattice.{ Lattice, NotMonotonicException, Key }
 
 object Util {
 
@@ -27,7 +27,7 @@ class PowerSetLattice[T] extends Lattice[Set[T]] {
   def join(left: Set[T], right: Set[T]): Set[T] =
     left ++ right
 
-  def empty: Set[T] =
+  def bottom: Set[T] =
     Set[T]()
 
 }

--- a/core/src/test/scala/opal/ImmutabilityLattice.scala
+++ b/core/src/test/scala/opal/ImmutabilityLattice.scala
@@ -1,7 +1,7 @@
 package opal
 
 import cell._
-import lattice.{ Lattice, Key }
+import lattice.{ MonotonicUpdater, Key, Lattice }
 
 object ImmutabilityKey extends Key[Immutability] {
 
@@ -31,17 +31,31 @@ case object Immutable extends Immutability
 object Immutability {
 
   implicit object ImmutabilityLattice extends Lattice[Immutability] {
-    override def join(current: Immutability, next: Immutability): Immutability = {
-      if (<=(next, current)) current
-      else next
+    override def join(v1: Immutability, v2: Immutability): Immutability = {
+      if (lteq(v2, v1)) v1
+      else v2
     }
 
-    def <=(lhs: Immutability, rhs: Immutability): Boolean = {
+    override def lteq(lhs: Immutability, rhs: Immutability): Boolean = {
       lhs == rhs || lhs == Immutable ||
         (lhs == ConditionallyImmutable && rhs != Immutable)
     }
 
-    override def empty: Immutability = Immutable
+    override def bottom: Immutability = Immutable
+  }
+
+  implicit object ImmutabilityUpdater extends MonotonicUpdater[Immutability] {
+    override def update(v1: Immutability, v2: Immutability): Immutability = {
+      if (lteq(v2, v1)) v1
+      else v2
+    }
+
+    def lteq(lhs: Immutability, rhs: Immutability): Boolean = {
+      lhs == rhs || lhs == Immutable ||
+        (lhs == ConditionallyImmutable && rhs != Immutable)
+    }
+
+    override def bottom: Immutability = Immutable
   }
 
 }

--- a/core/src/test/scala/opal/PurityLattice.scala
+++ b/core/src/test/scala/opal/PurityLattice.scala
@@ -1,7 +1,7 @@
 package opal
 
 import cell._
-import lattice.{ Lattice, LatticeViolationException, Key }
+import lattice.{ MonotonicUpdater, Key, Lattice, NotMonotonicException }
 
 object PurityKey extends Key[Purity] {
 
@@ -22,15 +22,13 @@ case object Pure extends Purity
 case object Impure extends Purity
 
 object Purity {
-
-  implicit object PurityLattice extends Lattice[Purity] {
-    override def join(current: Purity, next: Purity): Purity = {
-      if (current == UnknownPurity) next
-      else if (current == next) current
-      else throw LatticeViolationException(current, next)
+  implicit object PurityUpdater extends MonotonicUpdater[Purity] {
+    override def lteq(v1: Purity, v2: Purity): Boolean = {
+      if (v1 == UnknownPurity) true
+      else if (v1 == v2) true
+      else false
     }
 
-    override val empty: Purity = UnknownPurity
+    override val bottom: Purity = UnknownPurity
   }
-
 }

--- a/core/src/test/scala/pool.scala
+++ b/core/src/test/scala/pool.scala
@@ -6,7 +6,7 @@ import org.scalatest.FunSuite
 
 import scala.concurrent.{ Await, Promise }
 import scala.concurrent.duration._
-import lattice.{ Lattice, StringIntKey, StringIntLattice }
+import lattice.{ Lattice, StringIntKey, StringIntUpdater, Updater }
 
 class PoolSuite extends FunSuite {
   test("onQuiescent") {
@@ -31,7 +31,7 @@ class PoolSuite extends FunSuite {
   }
 
   test("register cells concurrently") {
-    implicit val stringIntLattice: Lattice[Int] = new StringIntLattice
+    implicit val stringIntUpdater: Updater[Int] = new StringIntUpdater
 
     implicit val pool = new HandlerPool()
     var regCells = new ConcurrentHashMap[Cell[StringIntKey, Int], Cell[StringIntKey, Int]]()
@@ -51,7 +51,7 @@ class PoolSuite extends FunSuite {
   }
 
   test("register cells concurrently 2") {
-    implicit val stringIntLattice: Lattice[Int] = new StringIntLattice
+    implicit val stringIntUpdater: Updater[Int] = new StringIntUpdater
 
     implicit val pool = new HandlerPool()
     var regCells = new ConcurrentHashMap[Cell[StringIntKey, Int], Cell[StringIntKey, Int]]()


### PR DESCRIPTION
When creating a cell, an `Updater` is passed to the constructor (instead of a lattice). This `updater` may
(a) join alls values that get put to the cell ( `AggregationUpater`) or
(b) check, if the new value is a refinement and then simple store it – or otherwise throw ( `MonotonicUpdater`).

We have discussed use cases for both approaches. Most of our test currently use (b).