### PR TITLE
[bugfix][minor] Compare to joined value in putFinal

### DIFF
--- a/core/src/main/scala/cell/Cell.scala
+++ b/core/src/main/scala/cell/Cell.scala
@@ -475,7 +475,9 @@ private class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, updater: U
     // the only call to `tryCompleteAndGetState`
     val res = tryCompleteAndGetState(resolved) match {
       case finalRes: Try[_] => // was already complete
-        val res = finalRes == value // FIXME: should compare to joined value
+        val finalResult = finalRes.asInstanceOf[Try[V]].get
+        val newVal = value.map(tryJoin(finalResult, _))
+        val res = finalRes == newVal
         res
 
       case (pre: State[K, V], newVal: Try[V]) =>

--- a/core/src/test/scala/cell/base.scala
+++ b/core/src/test/scala/cell/base.scala
@@ -63,9 +63,9 @@ class BaseSuite extends FunSuite {
 
     try {
       completer.putFinal(ConditionallyImmutable)
-      assert(false)
+      assert(true)
     } catch {
-      case ise: IllegalStateException => assert(true)
+      case ise: IllegalStateException => assert(false)
       case e: Exception => assert(false)
     }
 


### PR DESCRIPTION
When completed cells get updated, an exception is thrown only, if new information is added. This has been missing for putFinal, see #102 

One test had to be adapted, it seemed to be buggy.