### PR TITLE
Trigger whenNext on completion, even if whenComplete exists.

### DIFF
--- a/core/src/test/scala/pool.scala
+++ b/core/src/test/scala/pool.scala
@@ -68,5 +68,4 @@ class PoolSuite extends FunSuite {
     assert(regCells.size === 1000)
   }
 
-
 }


### PR DESCRIPTION
This fixes #100, i.e. it makes 
` ` ` 
completer2.putFinal(Set(1)) // (1)
cell1.whenNext(completer2.cell, _ => NextOutcome(Set(1))) // (2)
cell1.whenComplete(completer2.cell, _ => NoOutcome) // (3)
` ` ` 
running in parallel deterministic (see tests).

Also: Adapt tests that tested for old behaviour of whenNext.