### PR TITLE
Allow cell dependencies on itself.

### DIFF
--- a/core/src/main/scala/cell/Cell.scala
+++ b/core/src/main/scala/cell/Cell.scala
@@ -601,13 +601,13 @@ private class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, lattice: L
 
   // Schedules execution of `callback` when next intermediate result is available.
   override private[cell] def onNext[U](callback: Try[V] => U): Unit = {
-    val runnable = new NextConcurrentCallbackRunnable[K, V](pool, this, this, callback)
+    val runnable = new NextConcurrentCallbackRunnable[K, V](pool, null, this, callback) // NULL indicates that no cell is waiting for this callback.
     dispatchOrAddNextCallback(runnable)
   }
 
   // Schedules execution of `callback` when completed with final result.
   override def onComplete[U](callback: Try[V] => U): Unit = {
-    val runnable = new CompleteConcurrentCallbackRunnable[K, V](pool, this, this, callback)
+    val runnable = new CompleteConcurrentCallbackRunnable[K, V](pool, null, this, callback) // NULL indicates that no cell is waiting for this callback.
     dispatchOrAddCallback(runnable)
   }
 

--- a/core/src/main/scala/cell/HandlerPool.scala
+++ b/core/src/main/scala/cell/HandlerPool.scala
@@ -222,10 +222,8 @@ class HandlerPool(parallelism: Int = 8, unhandledExceptionHandler: Throwable => 
     for ((c, v) <- result) {
       cells.foreach(cell => {
         // Note that there is a better solution for this in https://github.com/phaller/reactive-async/pull/58
-        if (cell != c) {
-          c.removeNextCallbacks(cell)
-          c.removeCompleteCallbacks(cell)
-        }
+        c.removeNextCallbacks(cell)
+        c.removeCompleteCallbacks(cell)
       })
       c.resolveWithValue(v)
     }
@@ -241,10 +239,8 @@ class HandlerPool(parallelism: Int = 8, unhandledExceptionHandler: Throwable => 
     for ((c, v) <- result) {
       cells.foreach(cell => {
         // Note that there is a better solution for this in https://github.com/phaller/reactive-async/pull/58
-        if (cell != c) {
-          c.removeNextCallbacks(cell)
-          c.removeCompleteCallbacks(cell)
-        }
+        c.removeNextCallbacks(cell)
+        c.removeCompleteCallbacks(cell)
       })
       c.resolveWithValue(v)
     }


### PR DESCRIPTION
OPAL needs dependencies of the form
```
cell1.whenNextSequential(cell1, …)
```
which have not been handled in cycle resolution. Instead `onnext` and `oncomplete` on a cell have been implemented as a callback on itself
