### PR TITLE
[bugfix] Call whenNext callback immediately after creation

### DIFF
--- a/core/src/main/scala/cell/Cell.scala
+++ b/core/src/main/scala/cell/Cell.scala
@@ -648,6 +648,7 @@ private class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, updater: U
           case false => new State(current.res, current.tasksActive, current.completeDeps, current.completeCallbacks, current.nextDeps, current.nextCallbacks + (runnable.dependentCell -> List(runnable)))
         }
         if (!state.compareAndSet(pre, newState)) dispatchOrAddNextCallback(runnable)
+        else if (current.res != updater.bottom) runnable.execute()
     }
   }
 

--- a/core/src/test/scala/cell/PsSuite.scala
+++ b/core/src/test/scala/cell/PsSuite.scala
@@ -53,7 +53,6 @@ class PsSuite extends FunSuite {
 
     completer20.putNext(1)
     cell20.whenNextSequential(cell10, x => {
-      println("other0")
       if (x == 10) {
         completer20.putFinal(43)
       }
@@ -63,7 +62,6 @@ class PsSuite extends FunSuite {
     completer1.putNext(10)
 
     cell1.whenNext(cell1, _ => {
-      println("itself")
       NoOutcome
     })
 
@@ -82,7 +80,6 @@ class PsSuite extends FunSuite {
     }
 
     override def fallback[K <: Key[Int]](cells: Seq[Cell[K, Int]]): Seq[(Cell[K, Int], Int)] = {
-      println("fallback")
       cells.map(cell ⇒ (cell, cell.getResult()))
     }
 

--- a/core/src/test/scala/cell/base.scala
+++ b/core/src/test/scala/cell/base.scala
@@ -751,6 +751,7 @@ class BaseSuite extends FunSuite {
       val completer2 = CellCompleter[ImmutabilityKey.type, Immutability](ImmutabilityKey)
 
       val cell1 = completer1.cell
+      cell1.trigger()
 
       pool.execute(() => cell1.whenComplete(completer2.cell, x => {
         NoOutcome
@@ -762,7 +763,7 @@ class BaseSuite extends FunSuite {
       }))
       pool.execute(() => completer2.putFinal(Mutable))
 
-      val fut = pool.quiescentResolveCycles
+      val fut = pool.quiescentResolveCell
       Await.ready(fut, 2.seconds)
 
       if (expectedValue.isEmpty) expectedValue = Some(cell1.getResult())
@@ -826,6 +827,32 @@ class BaseSuite extends FunSuite {
     }
 
     pool.shutdown()
+  }
+
+  test("whenNext: concurrent put next") {
+    var exptectedValue: Option[Immutability] = None
+
+    for (_ <- 1 to 100) {
+      implicit val pool = new HandlerPool
+      val completer1 = CellCompleter[ImmutabilityKey.type, Immutability](ImmutabilityKey)
+      val completer2 = CellCompleter[ImmutabilityKey.type, Immutability](ImmutabilityKey)
+
+      val cell1 = completer1.cell
+
+      pool.execute(() => cell1.whenNext(completer2.cell, x => {
+        if (x == Mutable) NextOutcome(Mutable)
+        else NoOutcome
+      }))
+      pool.execute(() => completer2.putNext(Mutable))
+
+      val fut = pool.quiescentResolveDefaults
+      Await.ready(fut, 2.seconds)
+
+      if (exptectedValue.isEmpty) exptectedValue = Some(cell1.getResult())
+      else assert(cell1.getResult() == exptectedValue.get)
+
+      pool.shutdown()
+    }
   }
 
   test("whenNextSequential: One cell with several dependencies on the same cell concurrency test") {
@@ -1202,7 +1229,7 @@ class BaseSuite extends FunSuite {
     completer.putNext(Set(3, 5))
     cell.onNext {
       case Success(v) =>
-        assert(v === Set(3, 4, 5))
+        assert(v === Set(3, 4, 5) || v === Set(3, 5))
         latch.countDown()
       case Failure(e) =>
         assert(false)
@@ -1597,12 +1624,12 @@ class BaseSuite extends FunSuite {
     completer3.putNext(-1)
     completer4.putNext(-1)
 
-    // create a cSCC, assert that none of the callbacks get called.
-    cell1.whenNext(cell2, v => { assert(false); NextOutcome(-2) })
-    cell1.whenNext(cell3, v => { assert(false); NextOutcome(-2) })
-    cell2.whenNext(cell4, v => { assert(false); NextOutcome(-2) })
-    cell3.whenNext(cell4, v => { assert(false); NextOutcome(-2) })
-    cell4.whenNext(cell1, v => { assert(false); NextOutcome(-2) })
+    // create a cSCC, assert that none of the callbacks get called again.
+    cell1.whenNext(cell2, v => if (v != -1) { assert(false); NextOutcome(-2) } else NoOutcome)
+    cell1.whenNext(cell3, v => if (v != -1) { assert(false); NextOutcome(-2) } else NoOutcome)
+    cell2.whenNext(cell4, v => if (v != -1) { assert(false); NextOutcome(-2) } else NoOutcome)
+    cell3.whenNext(cell4, v => if (v != -1) { assert(false); NextOutcome(-2) } else NoOutcome)
+    cell4.whenNext(cell1, v => if (v != -1) { assert(false); NextOutcome(-2) } else NoOutcome)
 
     for (c <- List(cell1, cell2, cell3, cell4))
       c.onComplete {
@@ -1646,11 +1673,11 @@ class BaseSuite extends FunSuite {
     completer4.putNext(-1)
 
     // create a cSCC, assert that none of the callbacks get called.
-    cell1.whenNextSequential(cell2, v => { assert(false); NextOutcome(-2) })
-    cell1.whenNextSequential(cell3, v => { assert(false); NextOutcome(-2) })
-    cell2.whenNextSequential(cell4, v => { assert(false); NextOutcome(-2) })
-    cell3.whenNextSequential(cell4, v => { assert(false); NextOutcome(-2) })
-    cell4.whenNextSequential(cell1, v => { assert(false); NextOutcome(-2) })
+    cell1.whenNextSequential(cell2, v => if (v != -1) { assert(false); NextOutcome(-2) } else NoOutcome)
+    cell1.whenNextSequential(cell3, v => if (v != -1) { assert(false); NextOutcome(-2) } else NoOutcome)
+    cell2.whenNextSequential(cell4, v => if (v != -1) { assert(false); NextOutcome(-2) } else NoOutcome)
+    cell3.whenNextSequential(cell4, v => if (v != -1) { assert(false); NextOutcome(-2) } else NoOutcome)
+    cell4.whenNextSequential(cell1, v => if (v != -1) { assert(false); NextOutcome(-2) } else NoOutcome)
 
     for (c <- List(cell1, cell2, cell3, cell4))
       c.onComplete {
@@ -1693,12 +1720,12 @@ class BaseSuite extends FunSuite {
     completer3.putNext(-1)
     completer4.putNext(-1)
 
-    // create a cSCC, assert that none of the callbacks get called.
-    cell1.whenNext(cell2, v => { assert(false); NextOutcome(-2) })
-    cell1.whenNext(cell3, v => { assert(false); NextOutcome(-2) })
-    cell2.whenNext(cell4, v => { assert(false); NextOutcome(-2) })
-    cell3.whenNext(cell4, v => { assert(false); NextOutcome(-2) })
-    cell4.whenNext(cell1, v => { assert(false); NextOutcome(-2) })
+    // create a cSCC, assert that none of the callbacks get called again.
+    cell1.whenNext(cell2, v => if (v != -1) { assert(false); NextOutcome(-2) } else NoOutcome)
+    cell1.whenNext(cell3, v => if (v != -1) { assert(false); NextOutcome(-2) } else NoOutcome)
+    cell2.whenNext(cell4, v => if (v != -1) { assert(false); NextOutcome(-2) } else NoOutcome)
+    cell3.whenNext(cell4, v => if (v != -1) { assert(false); NextOutcome(-2) } else NoOutcome)
+    cell4.whenNext(cell1, v => if (v != -1) { assert(false); NextOutcome(-2) } else NoOutcome)
 
     for (c <- List(cell1, cell2, cell3, cell4))
       c.onComplete {
@@ -1741,11 +1768,11 @@ class BaseSuite extends FunSuite {
     completer4.putNext(-1)
 
     // create a cSCC, assert that none of the callbacks get called.
-    cell1.whenNextSequential(cell2, v => { assert(false); NextOutcome(-2) })
-    cell1.whenNextSequential(cell3, v => { assert(false); NextOutcome(-2) })
-    cell2.whenNextSequential(cell4, v => { assert(false); NextOutcome(-2) })
-    cell3.whenNextSequential(cell4, v => { assert(false); NextOutcome(-2) })
-    cell4.whenNextSequential(cell1, v => { assert(false); NextOutcome(-2) })
+    cell1.whenNextSequential(cell2, v => if (v != -1) { assert(false); NextOutcome(-2) } else NoOutcome)
+    cell1.whenNextSequential(cell3, v => if (v != -1) { assert(false); NextOutcome(-2) } else NoOutcome)
+    cell2.whenNextSequential(cell4, v => if (v != -1) { assert(false); NextOutcome(-2) } else NoOutcome)
+    cell3.whenNextSequential(cell4, v => if (v != -1) { assert(false); NextOutcome(-2) } else NoOutcome)
+    cell4.whenNextSequential(cell1, v => if (v != -1) { assert(false); NextOutcome(-2) } else NoOutcome)
 
     for (c <- List(cell1, cell2, cell3, cell4))
       c.onComplete {


### PR DESCRIPTION
Call whenNext callback immediately after creation, if value is not bottom.

A test has been added. Some tests had to be adapted.

This fixes #81 , but see gitter and the test for a discussion, why the signature has not been changed. (Instead, semantics of whenNext have been changed.)