### PR TITLE
Add organization in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@ import Dependencies._ // see project/Dependencies.scala
 import Util._         // see project/Util.scala
 
 val buildVersion = "0.2.0-SNAPSHOT"
+organization in ThisBuild := "com.phaller"
 
 def commonSettings = Seq(
   version in ThisBuild := buildVersion,


### PR DESCRIPTION
With this PR it is possible to add reactive async with `"com.phaller" % "reactive-async_2.12" % 0.2.0-SNAPSHOT` instead of `"reactive-async" % "reactive-async_2.12" % 0.2.0-SNAPSHOT`.