### PR TITLE
Use Runtime.getRuntime().availableProcessors() instead of hardcoded parallelism level

### DIFF
--- a/core/src/main/scala/com/phaller/rasync/HandlerPool.scala
+++ b/core/src/main/scala/com/phaller/rasync/HandlerPool.scala
@@ -20,7 +20,9 @@ private class PoolState(val handlers: List[() => Unit] = List(), val submittedTa
     submittedTasks == 0
 }
 
-class HandlerPool(parallelism: Int = 8, unhandledExceptionHandler: Throwable => Unit = _.printStackTrace()) {
+class HandlerPool(
+  parallelism: Int = Runtime.getRuntime.availableProcessors(),
+  unhandledExceptionHandler: Throwable => Unit = _.printStackTrace()) {
 
   private val pool: ForkJoinPool = new ForkJoinPool(parallelism)
 


### PR DESCRIPTION
Fixes #141 