### PR TITLE
[performance] Add priorities to tasks/callbacks.

### DIFF
--- a/core/src/main/scala/com/phaller/rasync/Cell.scala
+++ b/core/src/main/scala/com/phaller/rasync/Cell.scala
@@ -246,8 +246,6 @@ private class IntermediateState[K <: Key[V], V](
   val res: V,
   /** `true`, if the `init` method has been called.  */
   val tasksActive: Boolean,
-
-  // TODO can those be concurrent data structures? -> remove the need of CAS, in FinalState, we use TrieMaps
   /** A list of cells that depend on `this` cell. */
   val completeDependentCells: List[Cell[K, V]],
   /** A list of cells that `this` cell depends on mapped to the callbacks to call, if those cells change. */
@@ -1037,7 +1035,7 @@ private class CellImpl[K <: Key[V], V](pool: HandlerPool, val key: K, updater: U
           case _: FinalState[K, V] =>
           /* We are final already, so we ignore all incoming information. */
         }
-      })
+      }, pool.schedulingStrategy.calcPriority(this, otherCell))
     case _: FinalState[K, V] => /* We are final already, so we ignore all incoming information. */
   }
 

--- a/core/src/main/scala/com/phaller/rasync/SchedulingStrategy.scala
+++ b/core/src/main/scala/com/phaller/rasync/SchedulingStrategy.scala
@@ -1,0 +1,78 @@
+package com.phaller.rasync
+
+import com.phaller.rasync.lattice.Key
+
+/**
+ * A scheduling strategy defines priorities for dependency callbacks
+ * and cell resolution.
+ *
+ * Whenever a dependency is triggered due to a change of a dependee cell,
+ * a task is added to the handler pool. Those tasks will eventually be picked
+ * up and executed, potentielly concurrently to other tasks.
+ * Each task added to the pool is assigned a priority as defined by a
+ * SchedulingStrategy, where tasks with lower priorities are more likely
+ * to be executed earlier. (Note that due to concurrent execution there is
+ * no guarantee for any order of execution. Use sequential callbacks to
+ * avoid concurrent execution of certain tasks.)
+ *
+ * If a tasks has been created because of a change in a dependee cell `other` being propgated to
+ * a `dependentCell`, `SchedulingStrategy.calcPriority(dependentCell, other)` is called to
+ * obtain a priority.
+ * If a tasks has been created to complete a `cell` via a `Key`,
+ * `SchedulingStrategy.calcPriority(cell)` is called.
+ */
+trait SchedulingStrategy {
+  def calcPriority[K <: Key[V], V](dependentCell: Cell[K, V], other: Cell[K, V]): Int
+  def calcPriority[K <: Key[V], V](dependentCell: Cell[K, V]): Int
+
+}
+
+/** All tasks are of equal priority. */
+object DefaultScheduling extends SchedulingStrategy {
+  override def calcPriority[K <: Key[V], V](dependentCell: Cell[K, V], other: Cell[K, V]): Int = 0
+  override def calcPriority[K <: Key[V], V](cell: Cell[K, V]): Int = 0
+}
+
+object OthersWithManySuccessorsFirst extends SchedulingStrategy {
+  override def calcPriority[K <: Key[V], V](dependentCell: Cell[K, V], other: Cell[K, V]): Int =
+    -(other.numNextDependentCells + other.numCompleteDependentCells)
+
+  override def calcPriority[K <: Key[V], V](cell: Cell[K, V]): Int =
+    -(cell.numNextDependentCells + cell.numCompleteDependentCells)
+}
+
+object OthersWithManySuccessorsLast extends SchedulingStrategy {
+  override def calcPriority[K <: Key[V], V](dependentCell: Cell[K, V], other: Cell[K, V]): Int =
+    other.numNextDependentCells + other.numCompleteDependentCells
+
+  override def calcPriority[K <: Key[V], V](cell: Cell[K, V]): Int =
+    cell.numNextDependentCells + cell.numCompleteDependentCells
+}
+
+object CellsWithManyPredecessorsFirst extends SchedulingStrategy {
+  override def calcPriority[K <: Key[V], V](dependentCell: Cell[K, V], other: Cell[K, V]): Int =
+    -dependentCell.totalCellDependencies.size
+
+  override def calcPriority[K <: Key[V], V](cell: Cell[K, V]): Int = 0
+}
+
+object CellsWithManyPredecessorsLast extends SchedulingStrategy {
+  override def calcPriority[K <: Key[V], V](dependentCell: Cell[K, V], other: Cell[K, V]): Int =
+    dependentCell.totalCellDependencies.size
+
+  override def calcPriority[K <: Key[V], V](dependentCell: Cell[K, V]): Int = 0
+}
+
+object CellsWithManySuccessorsFirst extends SchedulingStrategy {
+  override def calcPriority[K <: Key[V], V](dependentCell: Cell[K, V], other: Cell[K, V]): Int =
+    -(dependentCell.numNextDependentCells + dependentCell.numCompleteDependentCells)
+
+  override def calcPriority[K <: Key[V], V](dependentCell: Cell[K, V]): Int = 0
+}
+
+object CellsWithManySuccessorsLast extends SchedulingStrategy {
+  override def calcPriority[K <: Key[V], V](dependentCell: Cell[K, V], other: Cell[K, V]): Int =
+    dependentCell.numNextDependentCells + dependentCell.numCompleteDependentCells
+
+  override def calcPriority[K <: Key[V], V](dependentCell: Cell[K, V]): Int = 0
+}

--- a/core/src/main/scala/com/phaller/rasync/callbackRunnable.scala
+++ b/core/src/main/scala/com/phaller/rasync/callbackRunnable.scala
@@ -39,7 +39,7 @@ private[rasync] trait CallbackRunnable[K <: Key[V], V] extends Runnable with OnC
   // faster, both execute() and peekFor() can be removed.
   def execute(): Unit =
     if (otherCell.peekFor(dependentCompleter.cell, completeDep) != NoOutcome) // for COMPLETECallbackRunnables, one could use != FinalOutcome
-      try pool.execute(this)
+      try pool.execute(this, pool.schedulingStrategy.calcPriority(dependentCompleter.cell, otherCell))
       catch { case NonFatal(t) => pool reportFailure t }
 
   /** Call the callback and use update dependentCompleter according to the callback's result. */

--- a/core/src/main/scala/com/phaller/rasync/outcome.scala
+++ b/core/src/main/scala/com/phaller/rasync/outcome.scala
@@ -35,14 +35,14 @@ object Outcome {
     valueOpt.map(value => if (isFinal) FinalOutcome(value) else NextOutcome(value)).getOrElse(NoOutcome)
 
   /**
-    * Returns a `NextOutcome`, `FinalOutcome`, or `NoOutcome` object.
-    *
-    * If `valueOpt` is `None`, `NoOutcome` is returned. Otherwise, a `NextOutcome` or
-    * `FinalOutcome` is returned depending on the boolean parameter.
-    *
-    * @param valueOpt  Option of a new value, a pair of a value V and a boolean to indicate if it is final.
-    * @return          Returns a `NextOutcome`, `FinalOutcome`, or `NoOutcome` object.
-    */
+   * Returns a `NextOutcome`, `FinalOutcome`, or `NoOutcome` object.
+   *
+   * If `valueOpt` is `None`, `NoOutcome` is returned. Otherwise, a `NextOutcome` or
+   * `FinalOutcome` is returned depending on the boolean parameter.
+   *
+   * @param valueOpt  Option of a new value, a pair of a value V and a boolean to indicate if it is final.
+   * @return          Returns a `NextOutcome`, `FinalOutcome`, or `NoOutcome` object.
+   */
   def apply[V](valueOpt: Option[(V, Boolean)]): Outcome[V] = valueOpt match {
     case Some((v, false)) => NextOutcome(v)
     case Some((v, true)) => FinalOutcome(v)


### PR DESCRIPTION
Each task that is added to the ThreadPoolExececutor by the HandlerPool is marked with a priority. High priority tasks are more likely to be executed earlier.

Priorities for whenNext, whenComplete, when are automatically computed by a SchedulingStrategy, that the users selects.

Use ForkJoinPool, if possible. (no strategy selected)

Tests with OPAL (L2PurityAnalysis, 8 to 18 threads) show ~5% speedup compared to current master branch.